### PR TITLE
Add recipe list page with star rating system

### DIFF
--- a/client/src/components/StarRating.tsx
+++ b/client/src/components/StarRating.tsx
@@ -1,0 +1,30 @@
+import { Star } from 'lucide-react'
+
+type Props = {
+  value: number | null
+  onChange?: (rating: number) => void
+}
+
+export function StarRating({ value, onChange }: Props) {
+  return (
+    <div className="flex gap-0.5">
+      {[1, 2, 3, 4, 5].map((star) => (
+        <button
+          key={star}
+          type="button"
+          onClick={() => onChange?.(star)}
+          disabled={!onChange}
+          className="text-slate-500 hover:text-amber-400 disabled:cursor-default transition-colors cursor-pointer disabled:pointer-events-none"
+        >
+          <Star
+            className={`size-5 ${
+              value !== null && star <= value
+                ? 'fill-amber-400 text-amber-400'
+                : ''
+            }`}
+          />
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/client/src/routeTree.gen.ts
+++ b/client/src/routeTree.gen.ts
@@ -9,38 +9,65 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as RecipesRouteImport } from './routes/recipes'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as RecipeRecipeIdRouteImport } from './routes/recipe.$recipeId'
 
+const RecipesRoute = RecipesRouteImport.update({
+  id: '/recipes',
+  path: '/recipes',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const RecipeRecipeIdRoute = RecipeRecipeIdRouteImport.update({
+  id: '/recipe/$recipeId',
+  path: '/recipe/$recipeId',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/recipes': typeof RecipesRoute
+  '/recipe/$recipeId': typeof RecipeRecipeIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/recipes': typeof RecipesRoute
+  '/recipe/$recipeId': typeof RecipeRecipeIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/recipes': typeof RecipesRoute
+  '/recipe/$recipeId': typeof RecipeRecipeIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/'
+  fullPaths: '/' | '/recipes' | '/recipe/$recipeId'
   fileRoutesByTo: FileRoutesByTo
-  to: '/'
-  id: '__root__' | '/'
+  to: '/' | '/recipes' | '/recipe/$recipeId'
+  id: '__root__' | '/' | '/recipes' | '/recipe/$recipeId'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  RecipesRoute: typeof RecipesRoute
+  RecipeRecipeIdRoute: typeof RecipeRecipeIdRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/recipes': {
+      id: '/recipes'
+      path: '/recipes'
+      fullPath: '/recipes'
+      preLoaderRoute: typeof RecipesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -48,11 +75,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/recipe/$recipeId': {
+      id: '/recipe/$recipeId'
+      path: '/recipe/$recipeId'
+      fullPath: '/recipe/$recipeId'
+      preLoaderRoute: typeof RecipeRecipeIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  RecipesRoute: RecipesRoute,
+  RecipeRecipeIdRoute: RecipeRecipeIdRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/client/src/routes/__root.tsx
+++ b/client/src/routes/__root.tsx
@@ -1,5 +1,6 @@
 import {
   HeadContent,
+  Link,
   Scripts,
   createRootRouteWithContext,
 } from '@tanstack/react-router'
@@ -26,12 +27,46 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
         content: 'width=device-width, initial-scale=1',
       },
       {
-        title: 'TanStack Start Starter',
+        title: 'Omlete',
       },
     ],
   }),
   shellComponent: RootDocument,
 })
+
+function NavBar() {
+  const linkClass =
+    'px-3 py-1.5 rounded-md text-sm font-medium transition-colors'
+  const activeClass = 'text-white bg-slate-700'
+  const inactiveClass = 'text-slate-400 hover:text-slate-200'
+
+  return (
+    <nav className="bg-slate-900 border-b border-slate-800">
+      <div className="max-w-2xl mx-auto px-4 flex items-center gap-6 h-14">
+        <Link to="/" className="text-xl font-bold tracking-tight text-white mr-4">
+          Omlete
+        </Link>
+        <Link
+          to="/"
+          className={linkClass}
+          activeProps={{ className: `${linkClass} ${activeClass}` }}
+          inactiveProps={{ className: `${linkClass} ${inactiveClass}` }}
+          activeOptions={{ exact: true }}
+        >
+          Create
+        </Link>
+        <Link
+          to="/recipes"
+          className={linkClass}
+          activeProps={{ className: `${linkClass} ${activeClass}` }}
+          inactiveProps={{ className: `${linkClass} ${inactiveClass}` }}
+        >
+          My Recipes
+        </Link>
+      </div>
+    </nav>
+  )
+}
 
 function RootDocument({ children }: { children: React.ReactNode }) {
   return (
@@ -39,8 +74,9 @@ function RootDocument({ children }: { children: React.ReactNode }) {
       <head>
         <HeadContent />
       </head>
-      <body>
+      <body className="bg-slate-900">
         <TanStackQueryProvider>
+          <NavBar />
           {children}
           <TanStackDevtools
             config={{

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -18,10 +18,7 @@ function App() {
   return (
     <div className="min-h-screen bg-linear-to-b from-slate-900 via-slate-800 to-slate-900 text-white">
       <div className="max-w-2xl mx-auto px-4 py-12">
-        <header className="mb-10">
-          <h1 className="text-4xl font-bold tracking-tight">Omlete</h1>
-          <p className="text-slate-400 mt-2">Generate or extract recipes with AI</p>
-        </header>
+        <p className="text-slate-400 mb-8">Generate or extract recipes with AI</p>
 
         <div className="flex gap-1 p-1 bg-slate-800 rounded-lg mb-8 w-fit">
           {(['generate', 'extract'] as const).map((t) => (

--- a/client/src/routes/recipe.$recipeId.tsx
+++ b/client/src/routes/recipe.$recipeId.tsx
@@ -1,0 +1,88 @@
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { ArrowLeft, Loader2 } from 'lucide-react'
+import { apiFetch } from '@/lib/api'
+import { RecipeCard } from '@/components/RecipeCard'
+import { StarRating } from '@/components/StarRating'
+import type { Recipe } from '@/components/RecipeCard'
+import '@/index.css'
+
+type RecipeDetail = Recipe & {
+  _id: string
+  rating: number | null
+  created_at: string
+}
+
+export const Route = createFileRoute('/recipe/$recipeId')({
+  component: RecipeDetailPage,
+})
+
+function RecipeDetailPage() {
+  const { recipeId } = Route.useParams()
+  const queryClient = useQueryClient()
+
+  const { data: recipe, isLoading } = useQuery({
+    queryKey: ['recipe', recipeId],
+    queryFn: async (): Promise<RecipeDetail> => {
+      const res = await apiFetch(`/api/recipes/${recipeId}`)
+      if (!res.ok) throw new Error('Recipe not found')
+      return res.json()
+    },
+  })
+
+  const ratingMutation = useMutation({
+    mutationFn: async (rating: number) => {
+      const res = await apiFetch(`/api/recipes/${recipeId}/rating`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rating }),
+      })
+      return res.json()
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['recipe', recipeId] })
+      queryClient.invalidateQueries({ queryKey: ['recipes'] })
+    },
+  })
+
+  return (
+    <div className="min-h-screen bg-linear-to-b from-slate-900 via-slate-800 to-slate-900 text-white">
+      <div className="max-w-2xl mx-auto px-4 py-12">
+        <Link
+          to="/recipes"
+          className="inline-flex items-center gap-1.5 text-sm text-slate-400 hover:text-white transition-colors mb-8"
+        >
+          <ArrowLeft className="size-4" />
+          Back to recipes
+        </Link>
+
+        {isLoading && (
+          <div className="flex items-center gap-2 text-slate-400">
+            <Loader2 className="size-5 animate-spin" />
+            Loading recipe...
+          </div>
+        )}
+
+        {recipe && (
+          <div className="space-y-6">
+            <div className="flex items-center justify-between">
+              <div className="text-sm text-slate-400">
+                {recipe.created_at
+                  ? new Date(recipe.created_at).toLocaleDateString()
+                  : ''}
+              </div>
+              <div className="flex items-center gap-3">
+                <span className="text-sm text-slate-400">Rate this recipe</span>
+                <StarRating
+                  value={recipe.rating}
+                  onChange={(rating) => ratingMutation.mutate(rating)}
+                />
+              </div>
+            </div>
+            <RecipeCard recipe={recipe} />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/client/src/routes/recipes.tsx
+++ b/client/src/routes/recipes.tsx
@@ -1,0 +1,105 @@
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Loader2 } from 'lucide-react'
+import { apiFetch } from '@/lib/api'
+import { StarRating } from '@/components/StarRating'
+import '@/index.css'
+
+type RecipeSummary = {
+  id: string
+  title: string
+  ingredient_count: number
+  rating: number | null
+  created_at: string | null
+}
+
+export const Route = createFileRoute('/recipes')({ component: RecipeList })
+
+function RecipeList() {
+  const queryClient = useQueryClient()
+
+  const { data: recipes, isLoading } = useQuery({
+    queryKey: ['recipes'],
+    queryFn: async (): Promise<RecipeSummary[]> => {
+      const res = await apiFetch('/api/recipes/')
+      return res.json()
+    },
+  })
+
+  const ratingMutation = useMutation({
+    mutationFn: async ({ id, rating }: { id: string; rating: number }) => {
+      const res = await apiFetch(`/api/recipes/${id}/rating`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rating }),
+      })
+      return res.json()
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['recipes'] })
+    },
+  })
+
+  return (
+    <div className="min-h-screen bg-linear-to-b from-slate-900 via-slate-800 to-slate-900 text-white">
+      <div className="max-w-2xl mx-auto px-4 py-12">
+        <h1 className="text-2xl font-bold tracking-tight mb-8">My Recipes</h1>
+
+        {isLoading && (
+          <div className="flex items-center gap-2 text-slate-400">
+            <Loader2 className="size-5 animate-spin" />
+            Loading recipes...
+          </div>
+        )}
+
+        {recipes && recipes.length === 0 && (
+          <div className="text-center py-16">
+            <p className="text-slate-400 mb-4">No recipes yet.</p>
+            <Link
+              to="/"
+              className="text-sm text-slate-300 hover:text-white underline underline-offset-4 transition-colors"
+            >
+              Create your first recipe
+            </Link>
+          </div>
+        )}
+
+        {recipes && recipes.length > 0 && (
+          <div className="space-y-3">
+            {recipes.map((recipe) => (
+              <div
+                key={recipe.id}
+                className="bg-slate-800 border border-slate-700 rounded-xl p-5 flex items-center gap-4"
+              >
+                <div className="flex-1 min-w-0">
+                  <Link
+                    to="/recipe/$recipeId"
+                    params={{ recipeId: recipe.id }}
+                    className="text-white font-medium hover:underline underline-offset-4"
+                  >
+                    {recipe.title}
+                  </Link>
+                  <div className="flex items-center gap-3 mt-1.5 text-sm text-slate-400">
+                    <span>{recipe.ingredient_count} ingredient{recipe.ingredient_count !== 1 ? 's' : ''}</span>
+                    <span className="text-slate-600">·</span>
+                    <span>
+                      {recipe.created_at
+                        ? new Date(recipe.created_at).toLocaleDateString()
+                        : 'Unknown date'}
+                    </span>
+                  </div>
+                </div>
+                <StarRating
+                  value={recipe.rating}
+                  onChange={(rating) =>
+                    ratingMutation.mutate({ id: recipe.id, rating })
+                  }
+                />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/render.yaml
+++ b/render.yaml
@@ -30,3 +30,6 @@ services:
     envVars:
       - key: VITE_API_URL
         value: https://omlete-api.onrender.com
+
+previewsEnabled: true
+previewsExpireAfterDays: 3

--- a/server/data_models/__init__.py
+++ b/server/data_models/__init__.py
@@ -1,4 +1,8 @@
+from datetime import datetime, timezone
+from typing import Optional
+
 from beanie import Document
+from pydantic import Field
 
 from lib.types import Ingredient, IngredientRecipe, Recipe
 
@@ -12,6 +16,8 @@ class IngredientDocument(Document, Ingredient):
 
 class RecipeDocument(Document, Recipe):
     ingredients: list[IngredientRecipe]
+    rating: Optional[int] = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     class Settings:
         name = "recipes"

--- a/server/lib/types.py
+++ b/server/lib/types.py
@@ -53,3 +53,7 @@ class QueryMatch(BaseModel):
 
 class SimilarIngredients(BaseModel):
     list[QueryMatch]
+
+
+class RatingUpdate(BaseModel):
+    rating: int = Field(ge=1, le=5)

--- a/server/main.py
+++ b/server/main.py
@@ -3,15 +3,15 @@ import base64
 from contextlib import asynccontextmanager
 
 from anthropic import AsyncAnthropic, transform_schema
-from beanie import init_beanie
+from beanie import PydanticObjectId, init_beanie
 from dotenv import load_dotenv
-from fastapi import APIRouter, FastAPI, UploadFile
+from fastapi import APIRouter, FastAPI, HTTPException, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import TypeAdapter
 
 from data_models import IngredientDocument, RecipeDocument
 from lib.db import get_motor_client, vo
-from lib.types import IngredientRecipe, RecipeModelResponse, RecipePrompt
+from lib.types import IngredientRecipe, RatingUpdate, RecipeModelResponse, RecipePrompt
 from tools import find_similar_ingredients
 
 load_dotenv()
@@ -120,6 +120,39 @@ async def _extract_and_save(file: UploadFile) -> RecipeDocument:
 @router.post("/recipes/extract-from-images/")
 async def extract_recipes_from_images(files: list[UploadFile]):
     return await asyncio.gather(*[_extract_and_save(f) for f in files])
+
+
+@router.get("/recipes/")
+async def list_recipes():
+    recipes = await RecipeDocument.find_all().sort("-created_at").to_list()
+    return [
+        {
+            "id": str(r.id),
+            "title": r.title,
+            "ingredient_count": len(r.ingredients),
+            "rating": r.rating,
+            "created_at": r.created_at.isoformat() if r.created_at else None,
+        }
+        for r in recipes
+    ]
+
+
+@router.get("/recipes/{recipe_id}")
+async def get_recipe(recipe_id: PydanticObjectId):
+    recipe = await RecipeDocument.get(recipe_id)
+    if not recipe:
+        raise HTTPException(status_code=404, detail="Recipe not found")
+    return recipe
+
+
+@router.patch("/recipes/{recipe_id}/rating")
+async def update_rating(recipe_id: PydanticObjectId, body: RatingUpdate):
+    recipe = await RecipeDocument.get(recipe_id)
+    if not recipe:
+        raise HTTPException(status_code=404, detail="Recipe not found")
+    recipe.rating = body.rating
+    await recipe.save()
+    return {"id": str(recipe.id), "rating": recipe.rating}
 
 
 app.include_router(router)


### PR DESCRIPTION
- Add rating (1-5) and created_at fields to RecipeDocument
- Add GET /api/recipes/ (list), GET /api/recipes/:id (detail), PATCH /api/recipes/:id/rating endpoints
- Create recipe list page at /recipes showing name, ingredient count, date, and interactive star rating
- Create recipe detail page at /recipe/:id with full recipe view and rating
- Add shared nav bar with Create and My Recipes links
- Add StarRating component using lucide-react Star icons

https://claude.ai/code/session_01AkFoUtSbx5UWFXY9zdGc7S