### PR TITLE
Add recipe list, star ratings, and meal planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,18 @@ Python 3.12 required. Install deps: `pip install -r requirements.txt`.
 - `src/lib/api.ts` — `apiFetch()` wrapper using `VITE_API_URL` env var
 - shadcn/ui components (New York style) in `src/components/ui/`
 - Route tree auto-generated at `src/routeTree.gen.ts` — do not edit manually
+- **Pages:** Create (`/`), My Recipes (`/recipes`), Recipe Detail (`/recipe/$recipeId`), Meal Plan (`/meal-plan`)
+- **Shared components:** `StarRating` (interactive 1-5 stars), `RecipeCard` (recipe display)
 
 ### Backend (`/server/`)
 
-- **FastAPI** with two endpoints: `POST /recipes/generate/` and `POST /recipes/extract-from-images/`
+- **FastAPI** with endpoints for recipe CRUD, rating, and meal planning:
+  - `POST /recipes/generate/` and `POST /recipes/extract-from-images/` — AI-powered recipe creation
+  - `GET /recipes/` — list all recipes (summary)
+  - `GET /recipes/{id}` — full recipe detail
+  - `PATCH /recipes/{id}/rating` — update star rating (1-5)
+  - `POST /meal-plan/suggest/` — suggest random recipes for a meal plan
+  - `POST /meal-plan/shopping-list/` — generate combined shopping list from selected recipes
 - **Beanie** (async MongoDB ODM) with two document types in `data_models/`: `IngredientDocument` (with 2048-dim Voyage-4 embeddings) and `RecipeDocument`
 - `tools.py` — defines the `find_similar_ingredients` Claude tool, which runs a MongoDB `$vectorSearch` to find semantically similar existing ingredients (threshold ≥ 0.9)
 - `lib/db.py` — MongoDB connection (Motor) and Voyage AI client setup

--- a/client/src/routeTree.gen.ts
+++ b/client/src/routeTree.gen.ts
@@ -10,12 +10,18 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as RecipesRouteImport } from './routes/recipes'
+import { Route as MealPlanRouteImport } from './routes/meal-plan'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as RecipeRecipeIdRouteImport } from './routes/recipe.$recipeId'
 
 const RecipesRoute = RecipesRouteImport.update({
   id: '/recipes',
   path: '/recipes',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const MealPlanRoute = MealPlanRouteImport.update({
+  id: '/meal-plan',
+  path: '/meal-plan',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -31,30 +37,34 @@ const RecipeRecipeIdRoute = RecipeRecipeIdRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/meal-plan': typeof MealPlanRoute
   '/recipes': typeof RecipesRoute
   '/recipe/$recipeId': typeof RecipeRecipeIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/meal-plan': typeof MealPlanRoute
   '/recipes': typeof RecipesRoute
   '/recipe/$recipeId': typeof RecipeRecipeIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/meal-plan': typeof MealPlanRoute
   '/recipes': typeof RecipesRoute
   '/recipe/$recipeId': typeof RecipeRecipeIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/recipes' | '/recipe/$recipeId'
+  fullPaths: '/' | '/meal-plan' | '/recipes' | '/recipe/$recipeId'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/recipes' | '/recipe/$recipeId'
-  id: '__root__' | '/' | '/recipes' | '/recipe/$recipeId'
+  to: '/' | '/meal-plan' | '/recipes' | '/recipe/$recipeId'
+  id: '__root__' | '/' | '/meal-plan' | '/recipes' | '/recipe/$recipeId'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  MealPlanRoute: typeof MealPlanRoute
   RecipesRoute: typeof RecipesRoute
   RecipeRecipeIdRoute: typeof RecipeRecipeIdRoute
 }
@@ -66,6 +76,13 @@ declare module '@tanstack/react-router' {
       path: '/recipes'
       fullPath: '/recipes'
       preLoaderRoute: typeof RecipesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/meal-plan': {
+      id: '/meal-plan'
+      path: '/meal-plan'
+      fullPath: '/meal-plan'
+      preLoaderRoute: typeof MealPlanRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -87,6 +104,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  MealPlanRoute: MealPlanRoute,
   RecipesRoute: RecipesRoute,
   RecipeRecipeIdRoute: RecipeRecipeIdRoute,
 }

--- a/client/src/routes/__root.tsx
+++ b/client/src/routes/__root.tsx
@@ -63,6 +63,14 @@ function NavBar() {
         >
           My Recipes
         </Link>
+        <Link
+          to="/meal-plan"
+          className={linkClass}
+          activeProps={{ className: `${linkClass} ${activeClass}` }}
+          inactiveProps={{ className: `${linkClass} ${inactiveClass}` }}
+        >
+          Meal Plan
+        </Link>
       </div>
     </nav>
   )

--- a/client/src/routes/meal-plan.tsx
+++ b/client/src/routes/meal-plan.tsx
@@ -1,0 +1,357 @@
+import { useState } from 'react'
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { useMutation, useQuery } from '@tanstack/react-query'
+import {
+  Loader2,
+  RefreshCw,
+  ChevronDown,
+  ShoppingBasket,
+  ArrowLeft,
+  RotateCcw,
+} from 'lucide-react'
+import { apiFetch } from '@/lib/api'
+import { StarRating } from '@/components/StarRating'
+import { Button } from '@/components/ui/button'
+import '@/index.css'
+
+type MealRecipe = {
+  _id: string
+  title: string
+  ingredients: { name: string; unit: string; amount: number }[]
+  rating: number | null
+}
+
+type ShoppingItem = {
+  name: string
+  unit: string
+  amount: number
+}
+
+type RecipeSummary = {
+  id: string
+  title: string
+  ingredient_count: number
+  rating: number | null
+  created_at: string | null
+}
+
+type Step = 'pick-days' | 'review' | 'shopping-list'
+
+export const Route = createFileRoute('/meal-plan')({ component: MealPlan })
+
+function MealPlan() {
+  const [step, setStep] = useState<Step>('pick-days')
+  const [days, setDays] = useState(0)
+  const [recipes, setRecipes] = useState<MealRecipe[]>([])
+  const [shoppingList, setShoppingList] = useState<ShoppingItem[]>([])
+  const [browseOpenIndex, setBrowseOpenIndex] = useState<number | null>(null)
+
+  const { data: allRecipes } = useQuery({
+    queryKey: ['recipes'],
+    queryFn: async (): Promise<RecipeSummary[]> => {
+      const res = await apiFetch('/api/recipes/')
+      return res.json()
+    },
+  })
+
+  const suggestMutation = useMutation({
+    mutationFn: async ({
+      numDays,
+      excludeIds,
+    }: {
+      numDays: number
+      excludeIds: string[]
+    }): Promise<MealRecipe[]> => {
+      const res = await apiFetch('/api/meal-plan/suggest/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ days: numDays, exclude_ids: excludeIds }),
+      })
+      return res.json()
+    },
+  })
+
+  const shoppingMutation = useMutation({
+    mutationFn: async (recipeIds: string[]): Promise<ShoppingItem[]> => {
+      const res = await apiFetch('/api/meal-plan/shopping-list/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ recipe_ids: recipeIds }),
+      })
+      return res.json()
+    },
+  })
+
+  const handlePickDays = async (n: number) => {
+    setDays(n)
+    const result = await suggestMutation.mutateAsync({
+      numDays: n,
+      excludeIds: [],
+    })
+    setRecipes(result)
+    setStep('review')
+  }
+
+  const handleSwap = async (index: number) => {
+    const excludeIds = recipes.map((r) => r._id)
+    const result = await suggestMutation.mutateAsync({
+      numDays: 1,
+      excludeIds,
+    })
+    if (result.length > 0) {
+      setRecipes((prev) => prev.map((r, i) => (i === index ? result[0] : r)))
+    }
+  }
+
+  const handleBrowseSelect = (index: number, recipeId: string) => {
+    const picked = allRecipes?.find((r) => r.id === recipeId)
+    if (!picked) return
+    const asRecipe: MealRecipe = {
+      _id: picked.id,
+      title: picked.title,
+      ingredients: [],
+      rating: picked.rating,
+    }
+    setRecipes((prev) => prev.map((r, i) => (i === index ? asRecipe : r)))
+    setBrowseOpenIndex(null)
+  }
+
+  const handleGenerateList = async () => {
+    const ids = recipes.map((r) => r._id)
+    const result = await shoppingMutation.mutateAsync(ids)
+    setShoppingList(result)
+    setStep('shopping-list')
+  }
+
+  const handleStartOver = () => {
+    setStep('pick-days')
+    setDays(0)
+    setRecipes([])
+    setShoppingList([])
+    setBrowseOpenIndex(null)
+  }
+
+  return (
+    <div className="min-h-screen bg-linear-to-b from-slate-900 via-slate-800 to-slate-900 text-white">
+      <div className="max-w-2xl mx-auto px-4 py-12">
+        <h1 className="text-2xl font-bold tracking-tight mb-8">Meal Plan</h1>
+
+        {/* Step 1: Pick Days */}
+        {step === 'pick-days' && (
+          <div className="space-y-6">
+            <p className="text-slate-400">
+              How many dinners do you need this week?
+            </p>
+            <div className="flex gap-3">
+              {[3, 4, 5, 6, 7].map((n) => (
+                <Button
+                  key={n}
+                  variant="outline"
+                  size="lg"
+                  className="border-slate-600 text-white hover:bg-slate-700 text-lg w-14 h-14"
+                  onClick={() => handlePickDays(n)}
+                  disabled={suggestMutation.isPending}
+                >
+                  {n}
+                </Button>
+              ))}
+            </div>
+            {suggestMutation.isPending && (
+              <div className="flex items-center gap-2 text-slate-400">
+                <Loader2 className="size-5 animate-spin" />
+                Finding recipes...
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Step 2: Review Plan */}
+        {step === 'review' && (
+          <div className="space-y-4">
+            {recipes.length < days && (
+              <p className="text-amber-400 text-sm">
+                You have {recipes.length} recipe
+                {recipes.length !== 1 ? 's' : ''} saved, but need {days}.{' '}
+                <Link
+                  to="/"
+                  className="underline underline-offset-4 hover:text-amber-300"
+                >
+                  Create more recipes
+                </Link>{' '}
+                to fill your plan.
+              </p>
+            )}
+
+            {recipes.length === 0 && (
+              <div className="text-center py-16">
+                <p className="text-slate-400 mb-4">
+                  No recipes available to plan with.
+                </p>
+                <Link
+                  to="/"
+                  className="text-sm text-slate-300 hover:text-white underline underline-offset-4 transition-colors"
+                >
+                  Create your first recipe
+                </Link>
+              </div>
+            )}
+
+            {recipes.map((recipe, index) => {
+              const currentIds = recipes.map((r) => r._id)
+              const browsableRecipes = allRecipes?.filter(
+                (r) => !currentIds.includes(r.id) || r.id === recipe._id,
+              )
+              const noAlternatives =
+                allRecipes && allRecipes.length <= recipes.length
+
+              return (
+                <div
+                  key={`${recipe._id}-${index}`}
+                  className="bg-slate-800 border border-slate-700 rounded-xl p-5"
+                >
+                  <div className="flex items-center gap-4">
+                    <span className="text-xs font-mono text-slate-500 shrink-0">
+                      Day {index + 1}
+                    </span>
+                    <div className="flex-1 min-w-0">
+                      <p className="text-white font-medium truncate">
+                        {recipe.title}
+                      </p>
+                      <div className="flex items-center gap-3 mt-1 text-sm text-slate-400">
+                        <span>
+                          {recipe.ingredients.length} ingredient
+                          {recipe.ingredients.length !== 1 ? 's' : ''}
+                        </span>
+                        <StarRating value={recipe.rating} />
+                      </div>
+                    </div>
+                    <div className="flex gap-2 shrink-0">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="text-slate-400 hover:text-white"
+                        onClick={() => handleSwap(index)}
+                        disabled={
+                          suggestMutation.isPending || !!noAlternatives
+                        }
+                        title="Random swap"
+                      >
+                        <RefreshCw className="size-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="text-slate-400 hover:text-white"
+                        onClick={() =>
+                          setBrowseOpenIndex(
+                            browseOpenIndex === index ? null : index,
+                          )
+                        }
+                        title="Browse recipes"
+                      >
+                        <ChevronDown
+                          className={`size-4 transition-transform ${browseOpenIndex === index ? 'rotate-180' : ''}`}
+                        />
+                      </Button>
+                    </div>
+                  </div>
+
+                  {browseOpenIndex === index && browsableRecipes && (
+                    <div className="mt-3 border-t border-slate-700 pt-3 max-h-48 overflow-y-auto space-y-1">
+                      {browsableRecipes.map((r) => (
+                        <button
+                          key={r.id}
+                          type="button"
+                          className={`w-full text-left px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer ${
+                            r.id === recipe._id
+                              ? 'bg-slate-600 text-white'
+                              : 'text-slate-300 hover:bg-slate-700 hover:text-white'
+                          }`}
+                          onClick={() => handleBrowseSelect(index, r.id)}
+                        >
+                          {r.title}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+
+            {recipes.length > 0 && (
+              <div className="flex gap-3 pt-4">
+                <Button
+                  variant="outline"
+                  className="border-slate-600 text-slate-300 hover:text-white"
+                  onClick={handleStartOver}
+                >
+                  <RotateCcw className="size-4 mr-2" />
+                  Start Over
+                </Button>
+                <Button
+                  className="bg-white text-slate-900 hover:bg-slate-200 flex-1"
+                  onClick={handleGenerateList}
+                  disabled={shoppingMutation.isPending}
+                >
+                  {shoppingMutation.isPending ? (
+                    <Loader2 className="size-4 mr-2 animate-spin" />
+                  ) : (
+                    <ShoppingBasket className="size-4 mr-2" />
+                  )}
+                  Generate Shopping List
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Step 3: Shopping List */}
+        {step === 'shopping-list' && (
+          <div className="space-y-6">
+            <div className="bg-slate-800 border border-slate-700 rounded-xl p-6">
+              <h2 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-4">
+                Shopping List
+              </h2>
+              {shoppingList.length === 0 ? (
+                <p className="text-slate-400 text-sm">No ingredients needed.</p>
+              ) : (
+                <ul className="space-y-2">
+                  {shoppingList.map((item, i) => (
+                    <li
+                      key={i}
+                      className="text-sm text-slate-300 flex gap-2"
+                    >
+                      <span className="text-white font-medium shrink-0">
+                        {item.amount} {item.unit}
+                      </span>
+                      <span>{item.name}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+
+            <div className="flex gap-3">
+              <Button
+                variant="outline"
+                className="border-slate-600 text-slate-300 hover:text-white"
+                onClick={() => setStep('review')}
+              >
+                <ArrowLeft className="size-4 mr-2" />
+                Back to Plan
+              </Button>
+              <Button
+                variant="outline"
+                className="border-slate-600 text-slate-300 hover:text-white"
+                onClick={handleStartOver}
+              >
+                <RotateCcw className="size-4 mr-2" />
+                Start Over
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/server/lib/types.py
+++ b/server/lib/types.py
@@ -57,3 +57,18 @@ class SimilarIngredients(BaseModel):
 
 class RatingUpdate(BaseModel):
     rating: int = Field(ge=1, le=5)
+
+
+class MealPlanRequest(BaseModel):
+    days: int = Field(ge=1, le=7)
+    exclude_ids: list[str] = []
+
+
+class ShoppingListRequest(BaseModel):
+    recipe_ids: list[str]
+
+
+class ShoppingListItem(BaseModel):
+    name: str
+    unit: str
+    amount: float

--- a/server/main.py
+++ b/server/main.py
@@ -1,5 +1,7 @@
 import asyncio
 import base64
+import random
+from collections import defaultdict
 from contextlib import asynccontextmanager
 
 from anthropic import AsyncAnthropic, transform_schema
@@ -11,7 +13,16 @@ from pydantic import TypeAdapter
 
 from data_models import IngredientDocument, RecipeDocument
 from lib.db import get_motor_client, vo
-from lib.types import IngredientRecipe, RatingUpdate, RecipeModelResponse, RecipePrompt
+from beanie.operators import In
+from lib.types import (
+    IngredientRecipe,
+    MealPlanRequest,
+    RatingUpdate,
+    RecipeModelResponse,
+    RecipePrompt,
+    ShoppingListItem,
+    ShoppingListRequest,
+)
 from tools import find_similar_ingredients
 
 load_dotenv()
@@ -153,6 +164,43 @@ async def update_rating(recipe_id: PydanticObjectId, body: RatingUpdate):
     recipe.rating = body.rating
     await recipe.save()
     return {"id": str(recipe.id), "rating": recipe.rating}
+
+
+@router.post("/meal-plan/suggest/")
+async def suggest_meal_plan(body: MealPlanRequest):
+    exclude_oids = [PydanticObjectId(eid) for eid in body.exclude_ids]
+    pipeline: list[dict] = []
+    if exclude_oids:
+        pipeline.append({"$match": {"_id": {"$nin": exclude_oids}}})
+    pipeline.append({"$sample": {"size": body.days}})
+    recipes = await RecipeDocument.aggregate(pipeline).to_list()
+    # If not enough from $sample (few docs), fall back to fetch all and sample
+    if len(recipes) < body.days:
+        if exclude_oids:
+            all_recipes = await RecipeDocument.find(
+                {"_id": {"$nin": exclude_oids}}
+            ).to_list()
+        else:
+            all_recipes = await RecipeDocument.find_all().to_list()
+        count = min(body.days, len(all_recipes))
+        return random.sample(all_recipes, count)
+    return recipes
+
+
+@router.post("/meal-plan/shopping-list/")
+async def generate_shopping_list(body: ShoppingListRequest):
+    oids = [PydanticObjectId(rid) for rid in body.recipe_ids]
+    recipes = await RecipeDocument.find(In(RecipeDocument.id, oids)).to_list()
+    totals: dict[tuple[str, str], float] = defaultdict(float)
+    for recipe in recipes:
+        for ing in recipe.ingredients:
+            totals[(ing.name, ing.unit)] += ing.amount
+    items = [
+        ShoppingListItem(name=name, unit=unit, amount=round(amount, 2))
+        for (name, unit), amount in totals.items()
+    ]
+    items.sort(key=lambda x: x.name.lower())
+    return items
 
 
 app.include_router(router)


### PR DESCRIPTION
## Summary
- **Recipe list page** (`/recipes`) — browse all saved recipes with title, ingredient count, date, and interactive star ratings
- **Recipe detail page** (`/recipe/$recipeId`) — full recipe view with rating
- **Star rating component** — reusable 1-5 star widget (interactive or read-only)
- **Meal planner** (`/meal-plan`) — 3-step flow: pick number of dinners → review/swap suggested recipes → generate merged shopping list
- **Shared nav bar** with links to Create, My Recipes, and Meal Plan
- **Backend endpoints**: GET/PATCH recipes, suggest random meals, generate combined shopping list
- Render preview environment support for branch deploys

## Test plan
- [ ] Navigate to `/recipes` — verify recipe list loads with ratings
- [ ] Click stars to rate a recipe, confirm it persists on refresh
- [ ] Click a recipe title to view detail page with full ingredients/instructions
- [ ] Navigate to `/meal-plan`, pick a day count, verify random recipes appear
- [ ] Swap a recipe using the random swap button, confirm it changes
- [ ] Use the browse dropdown to manually pick a recipe
- [ ] Generate shopping list, verify ingredients are merged and summed correctly
- [ ] `npx tsc --noEmit` passes with no errors

https://claude.ai/code/session_01AkFoUtSbx5UWFXY9zdGc7S