### PR TITLE
Multi-photo recipe extraction

### DIFF
--- a/client/src/routes/create.tsx
+++ b/client/src/routes/create.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
 import { useMutation } from '@tanstack/react-query'
-import { ImageIcon, Loader2, UploadCloud, X } from 'lucide-react'
+import { ImageIcon, Loader2, Plus, Trash2, UploadCloud, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { RecipeCard } from '@/components/RecipeCard'
 import type { Recipe } from '@/components/RecipeCard'
@@ -86,88 +86,203 @@ function GenerateTab() {
   )
 }
 
+type RecipeGroup = {
+  id: string
+  files: File[]
+}
+
 function ExtractTab() {
-  const inputRef = useRef<HTMLInputElement>(null)
-  const [files, setFiles] = useState<File[]>([])
+  const [groups, setGroups] = useState<RecipeGroup[]>([])
+  const [results, setResults] = useState<Recipe[]>([])
+  const [isExtracting, setIsExtracting] = useState(false)
+  const [progress, setProgress] = useState<number>(0)
 
-  const { mutate, data, isPending } = useMutation({
-    mutationFn: async (fs: File[]): Promise<Recipe[]> => {
+  const addGroup = () => {
+    setGroups((prev) => [...prev, { id: crypto.randomUUID(), files: [] }])
+  }
+
+  const removeGroup = (groupId: string) => {
+    setGroups((prev) => prev.filter((g) => g.id !== groupId))
+  }
+
+  const addFilesToGroup = (groupId: string, newFiles: File[]) => {
+    setGroups((prev) =>
+      prev.map((g) => (g.id === groupId ? { ...g, files: [...g.files, ...newFiles] } : g))
+    )
+  }
+
+  const removeFileFromGroup = (groupId: string, fileIndex: number) => {
+    setGroups((prev) =>
+      prev.map((g) =>
+        g.id === groupId ? { ...g, files: g.files.filter((_, i) => i !== fileIndex) } : g
+      )
+    )
+  }
+
+  const totalFiles = groups.reduce((sum, g) => sum + g.files.length, 0)
+
+  const handleExtract = async () => {
+    if (groups.length === 0 || totalFiles === 0) return
+    setIsExtracting(true)
+    setResults([])
+    setProgress(0)
+
+    for (let i = 0; i < groups.length; i++) {
+      const group = groups[i]
+      if (group.files.length === 0) continue
+      setProgress(i + 1)
+
       const form = new FormData()
-      fs.forEach((f) => form.append('files', f))
-      const res = await apiFetch('/api/recipes/extract-from-images/', {
-        method: 'POST',
-        body: form,
-      })
-      return res.json()
-    },
-  })
+      group.files.forEach((f) => form.append('files', f))
+      form.append('group_sizes', String(group.files.length))
 
-  const removeFile = (i: number) => setFiles((prev) => prev.filter((_, idx) => idx !== i))
+      try {
+        const res = await apiFetch('/api/recipes/extract-from-images/', {
+          method: 'POST',
+          body: form,
+        })
+        const recipes: Recipe[] = await res.json()
+        setResults((prev) => [...prev, ...recipes])
+      } catch {
+        // Continue with next group on error
+      }
+    }
 
-  const fileLabel =
-    files.length === 0
-      ? 'Extract Recipes'
-      : `Extract ${files.length} Recipe${files.length !== 1 ? 's' : ''}`
+    setIsExtracting(false)
+  }
 
   return (
     <div className="space-y-6">
-      <div>
-        <input
-          ref={inputRef}
-          type="file"
-          accept="image/*"
-          multiple
-          className="hidden"
-          onChange={(e) => {
-            setFiles((prev) => [...prev, ...Array.from(e.target.files ?? [])])
-            e.target.value = ''
-          }}
+      {/* Recipe groups */}
+      {groups.map((group, groupIndex) => (
+        <RecipeGroupRow
+          key={group.id}
+          index={groupIndex}
+          group={group}
+          onAddFiles={(files) => addFilesToGroup(group.id, files)}
+          onRemoveFile={(fileIndex) => removeFileFromGroup(group.id, fileIndex)}
+          onRemoveGroup={() => removeGroup(group.id)}
+          disabled={isExtracting}
         />
-        <button
-          onClick={() => inputRef.current?.click()}
-          className="w-full border-2 border-dashed border-slate-700 rounded-xl p-8 flex flex-col items-center gap-3 text-slate-400 hover:border-slate-500 hover:text-slate-300 transition-colors cursor-pointer"
+      ))}
+
+      {/* Add recipe button */}
+      <button
+        onClick={addGroup}
+        disabled={isExtracting}
+        className="w-full border-2 border-dashed border-slate-700 rounded-xl p-6 flex items-center justify-center gap-2 text-slate-400 hover:border-slate-500 hover:text-slate-300 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        <Plus className="size-5" />
+        <span className="text-sm font-medium">Add Recipe</span>
+      </button>
+
+      {/* Extract button */}
+      {groups.length > 0 && (
+        <Button
+          onClick={handleExtract}
+          disabled={isExtracting || totalFiles === 0}
+          className="w-full"
         >
-          <UploadCloud className="size-8" />
-          <span className="text-sm">Click to upload images</span>
-          <span className="text-xs text-slate-500">Photos of recipe books or screenshots</span>
-        </button>
+          {isExtracting ? (
+            <>
+              <Loader2 className="animate-spin" />
+              Extracting recipe {progress} of {groups.length}...
+            </>
+          ) : (
+            `Create ${groups.length} Recipe${groups.length !== 1 ? 's' : ''}`
+          )}
+        </Button>
+      )}
 
-        {files.length > 0 && (
-          <ul className="mt-3 space-y-2">
-            {files.map((f, i) => (
-              <li key={i} className="flex items-center gap-3 bg-slate-800 rounded-lg px-3 py-2">
-                <ImageIcon className="size-4 text-slate-400 shrink-0" />
-                <span className="text-sm text-slate-300 truncate flex-1">{f.name}</span>
-                <button
-                  onClick={() => removeFile(i)}
-                  className="text-slate-500 hover:text-slate-300 cursor-pointer"
-                >
-                  <X className="size-4" />
-                </button>
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
-
-      <Button onClick={() => mutate(files)} disabled={isPending || files.length === 0}>
-        {isPending ? (
-          <>
-            <Loader2 className="animate-spin" />
-            Extracting...
-          </>
-        ) : (
-          fileLabel
-        )}
-      </Button>
-
-      {data && (
+      {/* Results */}
+      {results.length > 0 && (
         <div className="space-y-4">
-          {data.map((recipe, i) => (
+          <h3 className="text-sm font-medium text-slate-400">
+            Extracted {results.length} recipe{results.length !== 1 ? 's' : ''}
+          </h3>
+          {results.map((recipe, i) => (
             <RecipeCard key={i} recipe={recipe} />
           ))}
         </div>
       )}
+    </div>
+  )
+}
+
+function RecipeGroupRow({
+  index,
+  group,
+  onAddFiles,
+  onRemoveFile,
+  onRemoveGroup,
+  disabled,
+}: {
+  index: number
+  group: RecipeGroup
+  onAddFiles: (files: File[]) => void
+  onRemoveFile: (fileIndex: number) => void
+  onRemoveGroup: () => void
+  disabled: boolean
+}) {
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  return (
+    <div className="bg-slate-800 border border-slate-700 rounded-lg p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-medium">Recipe {index + 1}</h3>
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          onClick={onRemoveGroup}
+          disabled={disabled}
+          className="text-slate-500 hover:text-red-400"
+        >
+          <Trash2 className="size-4" />
+        </Button>
+      </div>
+
+      {/* Photo thumbnails */}
+      {group.files.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {group.files.map((f, i) => (
+            <div
+              key={i}
+              className="relative group bg-slate-700 rounded-md px-3 py-2 flex items-center gap-2"
+            >
+              <ImageIcon className="size-4 text-slate-400 shrink-0" />
+              <span className="text-xs text-slate-300 truncate max-w-[120px]">{f.name}</span>
+              <button
+                onClick={() => onRemoveFile(i)}
+                disabled={disabled}
+                className="text-slate-500 hover:text-slate-300 cursor-pointer"
+              >
+                <X className="size-3.5" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Add photos button */}
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        multiple
+        className="hidden"
+        onChange={(e) => {
+          onAddFiles(Array.from(e.target.files ?? []))
+          e.target.value = ''
+        }}
+      />
+      <button
+        onClick={() => inputRef.current?.click()}
+        disabled={disabled}
+        className="flex items-center gap-2 text-sm text-slate-400 hover:text-slate-200 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        <UploadCloud className="size-4" />
+        Add photos
+      </button>
     </div>
   )
 }

--- a/server/main.py
+++ b/server/main.py
@@ -132,21 +132,25 @@ async def create_recipe(prompt: RecipePrompt):
     return await _save_recipe(recipe)
 
 
-async def _extract_and_save(file: UploadFile, categories_str: str) -> RecipeDocument:
-    data = base64.standard_b64encode(await file.read()).decode("utf-8")
+async def _extract_and_save(files: list[UploadFile], categories_str: str) -> RecipeDocument:
+    image_blocks = []
+    for file in files:
+        data = base64.standard_b64encode(await file.read()).decode("utf-8")
+        image_blocks.append({
+            "type": "image",
+            "source": {"type": "base64", "media_type": file.content_type, "data": data},
+        })
+    image_word = "this image" if len(files) == 1 else "these images"
     runner = async_claude.beta.messages.tool_runner(
         model="claude-opus-4-5",
         max_tokens=2048,
         messages=[{
             "role": "user",
             "content": [
-                {
-                    "type": "image",
-                    "source": {"type": "base64", "media_type": file.content_type, "data": data},
-                },
+                *image_blocks,
                 {
                     "type": "text",
-                    "text": f"Extract the recipe from this image. Use find_similar_ingredients to match ingredients against the database. For each NEW ingredient (is_new=true), assign a category from this list: [{categories_str}]. For existing ingredients matched via the tool, you may leave the category as 'Other'. Output the recipe in the given JSON format.",
+                    "text": f"Extract the recipe from {image_word}. The images may show different parts of the same recipe (e.g. ingredients on one page, method on another). Combine them into a single complete recipe. Use find_similar_ingredients to match ingredients against the database. For each NEW ingredient (is_new=true), assign a category from this list: [{categories_str}]. For existing ingredients matched via the tool, you may leave the category as 'Other'. Output the recipe in the given JSON format.",
                 },
             ],
         }],
@@ -160,10 +164,36 @@ async def _extract_and_save(file: UploadFile, categories_str: str) -> RecipeDocu
 
 
 @router.post("/recipes/extract-from-images/")
-async def extract_recipes_from_images(files: list[UploadFile]):
+async def extract_recipes_from_images(files: list[UploadFile], group_sizes: list[int] | None = None):
+    """Extract recipes from grouped images.
+
+    files: all image files, flattened
+    group_sizes: list of ints indicating how many files belong to each recipe group.
+                 e.g. [2, 1] means first 2 files = recipe 1, next 1 file = recipe 2.
+                 If omitted, each file is treated as a separate recipe (backward compatible).
+    """
     category_names = await _get_category_names()
     categories_str = ", ".join(category_names)
-    return await asyncio.gather(*[_extract_and_save(f, categories_str) for f in files])
+
+    if group_sizes:
+        # Split files into groups
+        groups: list[list[UploadFile]] = []
+        offset = 0
+        for size in group_sizes:
+            groups.append(files[offset:offset + size])
+            offset += size
+        results = []
+        for group in groups:
+            result = await _extract_and_save(group, categories_str)
+            results.append(result)
+        return results
+    else:
+        # Backward compatible: each file is one recipe
+        results = []
+        for f in files:
+            result = await _extract_and_save([f], categories_str)
+            results.append(result)
+        return results
 
 
 @router.get("/recipes/")


### PR DESCRIPTION
## Summary
Closes #33

- Replace flat file picker in Extract tab with recipe-row builder
- Each recipe row has its own photo picker (supports multiple photos per recipe)
- Backend sends all images for a recipe group as multiple content blocks in a single Claude call
- Recipes processed sequentially with progress indicator

## How it works
1. Click "Add Recipe" to create a recipe row
2. Add photos to each row (multiple photos = one recipe)
3. Add more recipe rows if needed
4. Click "Create N Recipes" to extract all

## Test plan
- [ ] Upload 2 photos for one recipe → verify single recipe extracted with content from both images
- [ ] Create 2 recipe groups → verify 2 separate recipes extracted
- [ ] Remove a photo / remove a recipe row → verify excluded
- [ ] Single photo per recipe still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)