### PR TITLE
Editable recipes with ingredient exclusion

### DIFF
--- a/client/src/components/RecipeCard.tsx
+++ b/client/src/components/RecipeCard.tsx
@@ -13,10 +13,10 @@ export function RecipeCard({ recipe }: { recipe: Recipe }) {
         <ul className="space-y-1.5">
           {recipe.ingredients.map((ing, i) => (
             <li key={i} className="text-sm text-slate-300 flex gap-2">
+              <span className="flex-1">{ing.name}</span>
               <span className="text-white font-medium shrink-0">
                 {ing.amount} {ing.unit}
               </span>
-              <span>{ing.name}</span>
             </li>
           ))}
         </ul>

--- a/client/src/components/RecipeCard.tsx
+++ b/client/src/components/RecipeCard.tsx
@@ -1,4 +1,4 @@
-type IngredientRecipe = { name: string; unit: string; amount: number }
+type IngredientRecipe = { name: string; unit: string; amount: number; category?: string; excluded_from_list?: boolean }
 export type Recipe = { title: string; instructions: string[]; ingredients: IngredientRecipe[] }
 
 export function RecipeCard({ recipe }: { recipe: Recipe }) {

--- a/client/src/routes/recipe.$recipeId.tsx
+++ b/client/src/routes/recipe.$recipeId.tsx
@@ -413,8 +413,8 @@ function RecipeDetailPage() {
                           ing.excluded_from_list ? 'opacity-40' : 'text-slate-300'
                         }`}
                       >
-                        <span className={`flex-1 ${ing.excluded_from_list ? 'line-through' : ''}`}>{ing.name}</span>
-                        <span className={`text-white font-medium shrink-0 ${ing.excluded_from_list ? 'line-through' : ''}`}>
+                        <span className="flex-1">{ing.name}</span>
+                        <span className="text-white font-medium shrink-0">
                           {ing.amount} {ing.unit}
                         </span>
                         <button

--- a/client/src/routes/recipe.$recipeId.tsx
+++ b/client/src/routes/recipe.$recipeId.tsx
@@ -11,7 +11,6 @@ import {
   Loader2,
   Pencil,
   Plus,
-  ShoppingCart,
   Trash2,
   X,
 } from 'lucide-react'
@@ -44,11 +43,6 @@ type RecipeDetail = Omit<Recipe, 'ingredients'> & {
   ingredients: IngredientRecipe[]
 }
 
-type ListSummary = {
-  id: string
-  name: string
-}
-
 type CategoryConfig = {
   name: string
   order: number
@@ -62,7 +56,6 @@ function RecipeDetailPage() {
   const { recipeId } = Route.useParams()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
-  const [addedToList, setAddedToList] = useState<string | null>(null)
   const [editing, setEditing] = useState(false)
   const [editTitle, setEditTitle] = useState('')
   const [editInstructions, setEditInstructions] = useState<string[]>([])
@@ -73,14 +66,6 @@ function RecipeDetailPage() {
     queryFn: async (): Promise<RecipeDetail> => {
       const res = await apiFetch(`/api/recipes/${recipeId}`)
       if (!res.ok) throw new Error('Recipe not found')
-      return res.json()
-    },
-  })
-
-  const { data: lists } = useQuery({
-    queryKey: ['lists'],
-    queryFn: async (): Promise<ListSummary[]> => {
-      const res = await apiFetch('/api/lists/')
       return res.json()
     },
   })
@@ -113,22 +98,6 @@ function RecipeDetailPage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['recipe', recipeId] })
       queryClient.invalidateQueries({ queryKey: ['recipes'] })
-    },
-  })
-
-  const addToList = useMutation({
-    mutationFn: async (listId: string) => {
-      const res = await apiFetch(`/api/lists/${listId}/recipes`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ recipe_id: recipeId }),
-      })
-      return res.json()
-    },
-    onSuccess: (_data, listId) => {
-      setAddedToList(listId)
-      queryClient.invalidateQueries({ queryKey: ['list', listId] })
-      queryClient.invalidateQueries({ queryKey: ['lists'] })
     },
   })
 
@@ -191,7 +160,6 @@ function RecipeDetailPage() {
     setEditing(false)
   }
 
-  const mostRecentList = lists?.[0]
   const sortedCategories = categories
     ? [...categories].sort((a, b) => a.order - b.order)
     : []
@@ -199,13 +167,48 @@ function RecipeDetailPage() {
   return (
     <div className="min-h-screen bg-linear-to-b from-slate-900 via-slate-800 to-slate-900 text-white">
       <div className="max-w-2xl mx-auto px-4 py-12">
-        <Link
-          to="/recipes"
-          className="inline-flex items-center gap-1.5 text-sm text-slate-400 hover:text-white transition-colors mb-6"
-        >
-          <ArrowLeft className="size-4" />
-          Back to recipes
-        </Link>
+        <div className="flex items-center justify-between mb-6">
+          <Link
+            to="/recipes"
+            className="inline-flex items-center gap-1.5 text-sm text-slate-400 hover:text-white transition-colors"
+          >
+            <ArrowLeft className="size-4" />
+            Back to recipes
+          </Link>
+          {recipe && !editing && (
+            <div className="flex items-center gap-2">
+              <Button variant="outline" size="sm" onClick={startEditing} className="gap-1.5 border-slate-700 text-slate-300">
+                <Pencil className="size-3.5" />
+                Edit
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  if (confirm('Delete this recipe? This cannot be undone.')) {
+                    deleteRecipe.mutate()
+                  }
+                }}
+                disabled={deleteRecipe.isPending}
+                className="gap-1.5 border-slate-700 text-red-400 hover:text-red-300 hover:border-red-400"
+              >
+                <Trash2 className="size-3.5" />
+                Delete
+              </Button>
+            </div>
+          )}
+          {editing && (
+            <div className="flex items-center gap-2">
+              <Button variant="ghost" size="sm" onClick={cancelEditing} className="text-slate-400">
+                Cancel
+              </Button>
+              <Button size="sm" onClick={() => saveRecipe.mutate()} disabled={saveRecipe.isPending} className="gap-1.5">
+                {saveRecipe.isPending ? <Loader2 className="size-3.5 animate-spin" /> : <Check className="size-3.5" />}
+                Save
+              </Button>
+            </div>
+          )}
+        </div>
 
         {isLoading && (
           <div className="flex items-center gap-2 text-slate-400">
@@ -242,73 +245,6 @@ function RecipeDetailPage() {
                 />
               </div>
             </div>
-
-            {/* Actions */}
-            {!editing && (
-              <div className="flex items-center gap-2 flex-wrap">
-                {addedToList ? (
-                  <Link
-                    to="/list/$listId"
-                    params={{ listId: addedToList }}
-                    className="inline-flex items-center gap-2 text-sm text-emerald-400 hover:text-emerald-300 transition-colors"
-                  >
-                    <Check className="size-4" />
-                    Added to {mostRecentList?.name} — view list
-                  </Link>
-                ) : mostRecentList ? (
-                  <Button
-                    onClick={() => addToList.mutate(mostRecentList.id)}
-                    disabled={addToList.isPending}
-                    size="sm"
-                    className="gap-1.5"
-                  >
-                    {addToList.isPending ? (
-                      <Loader2 className="size-3.5 animate-spin" />
-                    ) : (
-                      <ShoppingCart className="size-3.5" />
-                    )}
-                    Add to {mostRecentList.name}
-                  </Button>
-                ) : (
-                  <Link to="/">
-                    <Button variant="outline" size="sm" className="gap-1.5">
-                      <ShoppingCart className="size-3.5" />
-                      Create a list first
-                    </Button>
-                  </Link>
-                )}
-                <div className="flex-1" />
-                <Button variant="outline" size="sm" onClick={startEditing} className="gap-1.5 border-slate-700 text-slate-300">
-                  <Pencil className="size-3.5" />
-                  Edit
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => {
-                    if (confirm('Delete this recipe? This cannot be undone.')) {
-                      deleteRecipe.mutate()
-                    }
-                  }}
-                  disabled={deleteRecipe.isPending}
-                  className="gap-1.5 border-slate-700 text-red-400 hover:text-red-300 hover:border-red-400"
-                >
-                  <Trash2 className="size-3.5" />
-                  Delete
-                </Button>
-              </div>
-            )}
-            {editing && (
-              <div className="flex items-center gap-2">
-                <Button variant="ghost" size="sm" onClick={cancelEditing} className="text-slate-400">
-                  Cancel
-                </Button>
-                <Button size="sm" onClick={() => saveRecipe.mutate()} disabled={saveRecipe.isPending} className="gap-1.5">
-                  {saveRecipe.isPending ? <Loader2 className="size-3.5 animate-spin" /> : <Check className="size-3.5" />}
-                  Save
-                </Button>
-              </div>
-            )}
 
               {/* Ingredients */}
               <div>

--- a/client/src/routes/recipe.$recipeId.tsx
+++ b/client/src/routes/recipe.$recipeId.tsx
@@ -413,6 +413,10 @@ function RecipeDetailPage() {
                           ing.excluded_from_list ? 'opacity-40' : 'text-slate-300'
                         }`}
                       >
+                        <span className={`flex-1 ${ing.excluded_from_list ? 'line-through' : ''}`}>{ing.name}</span>
+                        <span className={`text-white font-medium shrink-0 ${ing.excluded_from_list ? 'line-through' : ''}`}>
+                          {ing.amount} {ing.unit}
+                        </span>
                         <button
                           onClick={() =>
                             toggleExclude.mutate({
@@ -429,10 +433,6 @@ function RecipeDetailPage() {
                             <Eye className="size-3.5" />
                           )}
                         </button>
-                        <span className={`text-white font-medium shrink-0 ${ing.excluded_from_list ? 'line-through' : ''}`}>
-                          {ing.amount} {ing.unit}
-                        </span>
-                        <span className={ing.excluded_from_list ? 'line-through' : ''}>{ing.name}</span>
                       </li>
                     ))}
                   </ul>

--- a/client/src/routes/recipe.$recipeId.tsx
+++ b/client/src/routes/recipe.$recipeId.tsx
@@ -1,23 +1,57 @@
 import { useState } from 'react'
-import { createFileRoute, Link } from '@tanstack/react-router'
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { ArrowLeft, Check, Loader2, ShoppingCart } from 'lucide-react'
+import {
+  ArrowLeft,
+  ArrowDown,
+  ArrowUp,
+  Check,
+  EyeOff,
+  Eye,
+  Loader2,
+  Pencil,
+  Plus,
+  ShoppingCart,
+  Trash2,
+  X,
+} from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { apiFetch } from '@/lib/api'
-import { RecipeCard } from '@/components/RecipeCard'
 import { StarRating } from '@/components/StarRating'
 import type { Recipe } from '@/components/RecipeCard'
 import '@/index.css'
 
-type RecipeDetail = Recipe & {
+type IngredientRecipe = {
+  name: string
+  unit: string
+  amount: number
+  category: string
+  excluded_from_list: boolean
+}
+
+type RecipeDetail = Omit<Recipe, 'ingredients'> & {
   _id: string
   rating: number | null
   created_at: string
+  ingredients: IngredientRecipe[]
 }
 
 type ListSummary = {
   id: string
   name: string
+}
+
+type CategoryConfig = {
+  name: string
+  order: number
 }
 
 export const Route = createFileRoute('/recipe/$recipeId')({
@@ -26,8 +60,13 @@ export const Route = createFileRoute('/recipe/$recipeId')({
 
 function RecipeDetailPage() {
   const { recipeId } = Route.useParams()
+  const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [addedToList, setAddedToList] = useState<string | null>(null)
+  const [editing, setEditing] = useState(false)
+  const [editTitle, setEditTitle] = useState('')
+  const [editInstructions, setEditInstructions] = useState<string[]>([])
+  const [editIngredients, setEditIngredients] = useState<IngredientRecipe[]>([])
 
   const { data: recipe, isLoading } = useQuery({
     queryKey: ['recipe', recipeId],
@@ -42,6 +81,22 @@ function RecipeDetailPage() {
     queryKey: ['lists'],
     queryFn: async (): Promise<ListSummary[]> => {
       const res = await apiFetch('/api/lists/')
+      return res.json()
+    },
+  })
+
+  const { data: categories } = useQuery({
+    queryKey: ['categories'],
+    queryFn: async (): Promise<CategoryConfig[]> => {
+      const res = await apiFetch('/api/settings/categories')
+      return res.json()
+    },
+  })
+
+  const { data: units } = useQuery({
+    queryKey: ['units'],
+    queryFn: async (): Promise<string[]> => {
+      const res = await apiFetch('/api/units')
       return res.json()
     },
   })
@@ -77,18 +132,115 @@ function RecipeDetailPage() {
     },
   })
 
+  const saveRecipe = useMutation({
+    mutationFn: async () => {
+      const res = await apiFetch(`/api/recipes/${recipeId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: editTitle,
+          instructions: editInstructions,
+          ingredients: editIngredients,
+        }),
+      })
+      return res.json()
+    },
+    onSuccess: () => {
+      setEditing(false)
+      queryClient.invalidateQueries({ queryKey: ['recipe', recipeId] })
+      queryClient.invalidateQueries({ queryKey: ['recipes'] })
+    },
+  })
+
+  const deleteRecipe = useMutation({
+    mutationFn: async () => {
+      await apiFetch(`/api/recipes/${recipeId}`, { method: 'DELETE' })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['recipes'] })
+      navigate({ to: '/recipes' })
+    },
+  })
+
+  const toggleExclude = useMutation({
+    mutationFn: async ({ index, excluded }: { index: number; excluded: boolean }) => {
+      const res = await apiFetch(
+        `/api/recipes/${recipeId}/ingredients/${index}/exclude`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ excluded }),
+        }
+      )
+      return res.json()
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['recipe', recipeId] })
+    },
+  })
+
+  const startEditing = () => {
+    if (!recipe) return
+    setEditTitle(recipe.title)
+    setEditInstructions([...recipe.instructions])
+    setEditIngredients(recipe.ingredients.map((i) => ({ ...i })))
+    setEditing(true)
+  }
+
+  const cancelEditing = () => {
+    setEditing(false)
+  }
+
   const mostRecentList = lists?.[0]
+  const sortedCategories = categories
+    ? [...categories].sort((a, b) => a.order - b.order)
+    : []
 
   return (
     <div className="min-h-screen bg-linear-to-b from-slate-900 via-slate-800 to-slate-900 text-white">
       <div className="max-w-2xl mx-auto px-4 py-12">
-        <Link
-          to="/recipes"
-          className="inline-flex items-center gap-1.5 text-sm text-slate-400 hover:text-white transition-colors mb-8"
-        >
-          <ArrowLeft className="size-4" />
-          Back to recipes
-        </Link>
+        <div className="flex items-center justify-between mb-8">
+          <Link
+            to="/recipes"
+            className="inline-flex items-center gap-1.5 text-sm text-slate-400 hover:text-white transition-colors"
+          >
+            <ArrowLeft className="size-4" />
+            Back to recipes
+          </Link>
+          {recipe && !editing && (
+            <div className="flex items-center gap-2">
+              <Button variant="outline" size="sm" onClick={startEditing} className="gap-1.5 border-slate-700 text-slate-300">
+                <Pencil className="size-3.5" />
+                Edit
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  if (confirm('Delete this recipe? This cannot be undone.')) {
+                    deleteRecipe.mutate()
+                  }
+                }}
+                disabled={deleteRecipe.isPending}
+                className="gap-1.5 border-slate-700 text-red-400 hover:text-red-300 hover:border-red-400"
+              >
+                <Trash2 className="size-3.5" />
+                Delete
+              </Button>
+            </div>
+          )}
+          {editing && (
+            <div className="flex items-center gap-2">
+              <Button variant="ghost" size="sm" onClick={cancelEditing} className="text-slate-400">
+                Cancel
+              </Button>
+              <Button size="sm" onClick={() => saveRecipe.mutate()} disabled={saveRecipe.isPending} className="gap-1.5">
+                {saveRecipe.isPending ? <Loader2 className="size-3.5 animate-spin" /> : <Check className="size-3.5" />}
+                Save
+              </Button>
+            </div>
+          )}
+        </div>
 
         {isLoading && (
           <div className="flex items-center gap-2 text-slate-400">
@@ -115,40 +267,260 @@ function RecipeDetailPage() {
             </div>
 
             {/* Add to list */}
-            <div className="flex items-center gap-3">
-              {addedToList ? (
-                <Link
-                  to="/list/$listId"
-                  params={{ listId: addedToList }}
-                  className="inline-flex items-center gap-2 text-sm text-emerald-400 hover:text-emerald-300 transition-colors"
-                >
-                  <Check className="size-4" />
-                  Added to {mostRecentList?.name} — view list
-                </Link>
-              ) : mostRecentList ? (
-                <Button
-                  onClick={() => addToList.mutate(mostRecentList.id)}
-                  disabled={addToList.isPending}
-                  className="gap-2"
-                >
-                  {addToList.isPending ? (
-                    <Loader2 className="size-4 animate-spin" />
-                  ) : (
-                    <ShoppingCart className="size-4" />
-                  )}
-                  Add to {mostRecentList.name}
-                </Button>
-              ) : (
-                <Link to="/">
-                  <Button variant="outline" className="gap-2">
-                    <ShoppingCart className="size-4" />
-                    Create a list first
+            {!editing && (
+              <div className="flex items-center gap-3">
+                {addedToList ? (
+                  <Link
+                    to="/list/$listId"
+                    params={{ listId: addedToList }}
+                    className="inline-flex items-center gap-2 text-sm text-emerald-400 hover:text-emerald-300 transition-colors"
+                  >
+                    <Check className="size-4" />
+                    Added to {mostRecentList?.name} — view list
+                  </Link>
+                ) : mostRecentList ? (
+                  <Button
+                    onClick={() => addToList.mutate(mostRecentList.id)}
+                    disabled={addToList.isPending}
+                    className="gap-2"
+                  >
+                    {addToList.isPending ? (
+                      <Loader2 className="size-4 animate-spin" />
+                    ) : (
+                      <ShoppingCart className="size-4" />
+                    )}
+                    Add to {mostRecentList.name}
                   </Button>
-                </Link>
-              )}
-            </div>
+                ) : (
+                  <Link to="/">
+                    <Button variant="outline" className="gap-2">
+                      <ShoppingCart className="size-4" />
+                      Create a list first
+                    </Button>
+                  </Link>
+                )}
+              </div>
+            )}
 
-            <RecipeCard recipe={recipe} />
+            {/* Recipe content */}
+            <div className="bg-slate-800 border border-slate-700 rounded-xl p-6 space-y-5">
+              {/* Title */}
+              {editing ? (
+                <Input
+                  value={editTitle}
+                  onChange={(e) => setEditTitle(e.target.value)}
+                  className="text-xl font-semibold bg-slate-700 border-slate-600 text-white h-auto py-2"
+                />
+              ) : (
+                <h2 className="text-xl font-semibold text-white">{recipe.title}</h2>
+              )}
+
+              {/* Ingredients */}
+              <div>
+                <h3 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-3">
+                  Ingredients
+                </h3>
+                {editing ? (
+                  <div className="space-y-2">
+                    {editIngredients.map((ing, i) => (
+                      <div key={i} className="flex items-center gap-2">
+                        <Input
+                          value={ing.name}
+                          onChange={(e) => {
+                            const updated = [...editIngredients]
+                            updated[i] = { ...updated[i], name: e.target.value }
+                            setEditIngredients(updated)
+                          }}
+                          placeholder="Name"
+                          className="flex-1 h-9 bg-slate-700 border-slate-600 text-white text-sm"
+                        />
+                        <Input
+                          type="number"
+                          value={ing.amount}
+                          onChange={(e) => {
+                            const updated = [...editIngredients]
+                            updated[i] = { ...updated[i], amount: parseFloat(e.target.value) || 0 }
+                            setEditIngredients(updated)
+                          }}
+                          placeholder="Qty"
+                          className="w-20 h-9 bg-slate-700 border-slate-600 text-white text-sm"
+                        />
+                        <Select
+                          value={ing.unit}
+                          onValueChange={(val) => {
+                            const updated = [...editIngredients]
+                            updated[i] = { ...updated[i], unit: val }
+                            setEditIngredients(updated)
+                          }}
+                        >
+                          <SelectTrigger className="w-28 h-9 bg-slate-700 border-slate-600 text-white text-sm">
+                            <SelectValue placeholder="Unit" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {units?.map((u) => (
+                              <SelectItem key={u} value={u}>{u}</SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <Select
+                          value={ing.category}
+                          onValueChange={(val) => {
+                            const updated = [...editIngredients]
+                            updated[i] = { ...updated[i], category: val }
+                            setEditIngredients(updated)
+                          }}
+                        >
+                          <SelectTrigger className="w-36 h-9 bg-slate-700 border-slate-600 text-white text-sm">
+                            <SelectValue placeholder="Category" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {sortedCategories.map((c) => (
+                              <SelectItem key={c.name} value={c.name}>{c.name}</SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <Button
+                          variant="ghost"
+                          size="icon-xs"
+                          onClick={() => setEditIngredients(editIngredients.filter((_, idx) => idx !== i))}
+                          className="shrink-0 size-8 text-slate-500 hover:text-red-400"
+                        >
+                          <Trash2 className="size-3.5" />
+                        </Button>
+                      </div>
+                    ))}
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() =>
+                        setEditIngredients([
+                          ...editIngredients,
+                          { name: '', unit: '', amount: 0, category: 'Other', excluded_from_list: false },
+                        ])
+                      }
+                      className="gap-1.5 text-slate-400 hover:text-white"
+                    >
+                      <Plus className="size-3.5" />
+                      Add ingredient
+                    </Button>
+                  </div>
+                ) : (
+                  <ul className="space-y-1.5">
+                    {recipe.ingredients.map((ing, i) => (
+                      <li
+                        key={i}
+                        className={`text-sm flex items-center gap-2 ${
+                          ing.excluded_from_list ? 'opacity-40' : 'text-slate-300'
+                        }`}
+                      >
+                        <button
+                          onClick={() =>
+                            toggleExclude.mutate({
+                              index: i,
+                              excluded: !ing.excluded_from_list,
+                            })
+                          }
+                          className="shrink-0 text-slate-500 hover:text-slate-300 transition-colors cursor-pointer"
+                          title={ing.excluded_from_list ? 'Include in shopping list' : 'Exclude from shopping list'}
+                        >
+                          {ing.excluded_from_list ? (
+                            <EyeOff className="size-3.5" />
+                          ) : (
+                            <Eye className="size-3.5" />
+                          )}
+                        </button>
+                        <span className={`text-white font-medium shrink-0 ${ing.excluded_from_list ? 'line-through' : ''}`}>
+                          {ing.amount} {ing.unit}
+                        </span>
+                        <span className={ing.excluded_from_list ? 'line-through' : ''}>{ing.name}</span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+
+              {/* Instructions */}
+              <div>
+                <h3 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-3">
+                  Instructions
+                </h3>
+                {editing ? (
+                  <div className="space-y-2">
+                    {editInstructions.map((step, i) => (
+                      <div key={i} className="flex items-start gap-2">
+                        <span className="text-slate-500 font-mono text-sm pt-2.5 shrink-0">{i + 1}.</span>
+                        <textarea
+                          value={step}
+                          onChange={(e) => {
+                            const updated = [...editInstructions]
+                            updated[i] = e.target.value
+                            setEditInstructions(updated)
+                          }}
+                          rows={2}
+                          className="flex-1 bg-slate-700 border border-slate-600 rounded-md px-3 py-2 text-sm text-white resize-none focus:outline-none focus:ring-2 focus:ring-slate-500"
+                        />
+                        <div className="flex flex-col gap-0.5 shrink-0">
+                          <Button
+                            variant="ghost"
+                            size="icon-xs"
+                            onClick={() => {
+                              if (i === 0) return
+                              const updated = [...editInstructions]
+                              ;[updated[i - 1], updated[i]] = [updated[i], updated[i - 1]]
+                              setEditInstructions(updated)
+                            }}
+                            disabled={i === 0}
+                            className="size-7 text-slate-500 hover:text-white"
+                          >
+                            <ArrowUp className="size-3.5" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon-xs"
+                            onClick={() => {
+                              if (i === editInstructions.length - 1) return
+                              const updated = [...editInstructions]
+                              ;[updated[i], updated[i + 1]] = [updated[i + 1], updated[i]]
+                              setEditInstructions(updated)
+                            }}
+                            disabled={i === editInstructions.length - 1}
+                            className="size-7 text-slate-500 hover:text-white"
+                          >
+                            <ArrowDown className="size-3.5" />
+                          </Button>
+                        </div>
+                        <Button
+                          variant="ghost"
+                          size="icon-xs"
+                          onClick={() => setEditInstructions(editInstructions.filter((_, idx) => idx !== i))}
+                          className="shrink-0 size-7 mt-1.5 text-slate-500 hover:text-red-400"
+                        >
+                          <X className="size-3.5" />
+                        </Button>
+                      </div>
+                    ))}
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setEditInstructions([...editInstructions, ''])}
+                      className="gap-1.5 text-slate-400 hover:text-white"
+                    >
+                      <Plus className="size-3.5" />
+                      Add step
+                    </Button>
+                  </div>
+                ) : (
+                  <ol className="space-y-2.5">
+                    {recipe.instructions.map((step, i) => (
+                      <li key={i} className="text-sm text-slate-300 flex gap-3">
+                        <span className="text-slate-500 font-mono shrink-0 pt-px">{i + 1}.</span>
+                        <span>{step}</span>
+                      </li>
+                    ))}
+                  </ol>
+                )}
+              </div>
+            </div>
           </div>
         )}
       </div>

--- a/client/src/routes/recipe.$recipeId.tsx
+++ b/client/src/routes/recipe.$recipeId.tsx
@@ -199,48 +199,13 @@ function RecipeDetailPage() {
   return (
     <div className="min-h-screen bg-linear-to-b from-slate-900 via-slate-800 to-slate-900 text-white">
       <div className="max-w-2xl mx-auto px-4 py-12">
-        <div className="flex items-center justify-between mb-8">
-          <Link
-            to="/recipes"
-            className="inline-flex items-center gap-1.5 text-sm text-slate-400 hover:text-white transition-colors"
-          >
-            <ArrowLeft className="size-4" />
-            Back to recipes
-          </Link>
-          {recipe && !editing && (
-            <div className="flex items-center gap-2">
-              <Button variant="outline" size="sm" onClick={startEditing} className="gap-1.5 border-slate-700 text-slate-300">
-                <Pencil className="size-3.5" />
-                Edit
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  if (confirm('Delete this recipe? This cannot be undone.')) {
-                    deleteRecipe.mutate()
-                  }
-                }}
-                disabled={deleteRecipe.isPending}
-                className="gap-1.5 border-slate-700 text-red-400 hover:text-red-300 hover:border-red-400"
-              >
-                <Trash2 className="size-3.5" />
-                Delete
-              </Button>
-            </div>
-          )}
-          {editing && (
-            <div className="flex items-center gap-2">
-              <Button variant="ghost" size="sm" onClick={cancelEditing} className="text-slate-400">
-                Cancel
-              </Button>
-              <Button size="sm" onClick={() => saveRecipe.mutate()} disabled={saveRecipe.isPending} className="gap-1.5">
-                {saveRecipe.isPending ? <Loader2 className="size-3.5 animate-spin" /> : <Check className="size-3.5" />}
-                Save
-              </Button>
-            </div>
-          )}
-        </div>
+        <Link
+          to="/recipes"
+          className="inline-flex items-center gap-1.5 text-sm text-slate-400 hover:text-white transition-colors mb-6"
+        >
+          <ArrowLeft className="size-4" />
+          Back to recipes
+        </Link>
 
         {isLoading && (
           <div className="flex items-center gap-2 text-slate-400">
@@ -250,7 +215,19 @@ function RecipeDetailPage() {
         )}
 
         {recipe && (
-          <div className="space-y-6">
+          <div className="bg-slate-800 border border-slate-700 rounded-xl p-6 space-y-5">
+            {/* Title */}
+            {editing ? (
+              <Input
+                value={editTitle}
+                onChange={(e) => setEditTitle(e.target.value)}
+                className="text-xl font-semibold bg-slate-700 border-slate-600 text-white h-auto py-2"
+              />
+            ) : (
+              <h2 className="text-xl font-semibold text-white">{recipe.title}</h2>
+            )}
+
+            {/* Date + Rating */}
             <div className="flex items-center justify-between">
               <div className="text-sm text-slate-400">
                 {recipe.created_at
@@ -258,7 +235,7 @@ function RecipeDetailPage() {
                   : ''}
               </div>
               <div className="flex items-center gap-3">
-                <span className="text-sm text-slate-400">Rate this recipe</span>
+                <span className="text-sm text-slate-400">Rate</span>
                 <StarRating
                   value={recipe.rating}
                   onChange={(rating) => ratingMutation.mutate(rating)}
@@ -266,9 +243,9 @@ function RecipeDetailPage() {
               </div>
             </div>
 
-            {/* Add to list */}
+            {/* Actions */}
             {!editing && (
-              <div className="flex items-center gap-3">
+              <div className="flex items-center gap-2 flex-wrap">
                 {addedToList ? (
                   <Link
                     to="/list/$listId"
@@ -282,38 +259,56 @@ function RecipeDetailPage() {
                   <Button
                     onClick={() => addToList.mutate(mostRecentList.id)}
                     disabled={addToList.isPending}
-                    className="gap-2"
+                    size="sm"
+                    className="gap-1.5"
                   >
                     {addToList.isPending ? (
-                      <Loader2 className="size-4 animate-spin" />
+                      <Loader2 className="size-3.5 animate-spin" />
                     ) : (
-                      <ShoppingCart className="size-4" />
+                      <ShoppingCart className="size-3.5" />
                     )}
                     Add to {mostRecentList.name}
                   </Button>
                 ) : (
                   <Link to="/">
-                    <Button variant="outline" className="gap-2">
-                      <ShoppingCart className="size-4" />
+                    <Button variant="outline" size="sm" className="gap-1.5">
+                      <ShoppingCart className="size-3.5" />
                       Create a list first
                     </Button>
                   </Link>
                 )}
+                <div className="flex-1" />
+                <Button variant="outline" size="sm" onClick={startEditing} className="gap-1.5 border-slate-700 text-slate-300">
+                  <Pencil className="size-3.5" />
+                  Edit
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    if (confirm('Delete this recipe? This cannot be undone.')) {
+                      deleteRecipe.mutate()
+                    }
+                  }}
+                  disabled={deleteRecipe.isPending}
+                  className="gap-1.5 border-slate-700 text-red-400 hover:text-red-300 hover:border-red-400"
+                >
+                  <Trash2 className="size-3.5" />
+                  Delete
+                </Button>
               </div>
             )}
-
-            {/* Recipe content */}
-            <div className="bg-slate-800 border border-slate-700 rounded-xl p-6 space-y-5">
-              {/* Title */}
-              {editing ? (
-                <Input
-                  value={editTitle}
-                  onChange={(e) => setEditTitle(e.target.value)}
-                  className="text-xl font-semibold bg-slate-700 border-slate-600 text-white h-auto py-2"
-                />
-              ) : (
-                <h2 className="text-xl font-semibold text-white">{recipe.title}</h2>
-              )}
+            {editing && (
+              <div className="flex items-center gap-2">
+                <Button variant="ghost" size="sm" onClick={cancelEditing} className="text-slate-400">
+                  Cancel
+                </Button>
+                <Button size="sm" onClick={() => saveRecipe.mutate()} disabled={saveRecipe.isPending} className="gap-1.5">
+                  {saveRecipe.isPending ? <Loader2 className="size-3.5 animate-spin" /> : <Check className="size-3.5" />}
+                  Save
+                </Button>
+              </div>
+            )}
 
               {/* Ingredients */}
               <div>
@@ -520,7 +515,6 @@ function RecipeDetailPage() {
                   </ol>
                 )}
               </div>
-            </div>
           </div>
         )}
       </div>

--- a/server/lib/types.py
+++ b/server/lib/types.py
@@ -21,6 +21,7 @@ class IngredientRecipe(BaseModel):
     )
     amount: float
     category: str = Field(default="Other")
+    excluded_from_list: bool = Field(default=False)
 
 
 class IngredientModelResponse(IngredientRecipe):
@@ -60,6 +61,16 @@ class SimilarIngredients(BaseModel):
 
 class RatingUpdate(BaseModel):
     rating: int = Field(ge=1, le=5)
+
+
+class RecipeUpdateRequest(BaseModel):
+    title: str
+    instructions: list[str]
+    ingredients: list[IngredientRecipe]
+
+
+class ExcludeUpdateRequest(BaseModel):
+    excluded: bool
 
 
 class ItemCreateRequest(BaseModel):

--- a/server/main.py
+++ b/server/main.py
@@ -18,6 +18,7 @@ from lib.types import (
     CategoriesUpdateRequest,
     CategorizeRequest,
     CategorizeResponse,
+    ExcludeUpdateRequest,
     IngredientRecipe,
     ItemCreateRequest,
     ItemUpdateRequest,
@@ -25,6 +26,7 @@ from lib.types import (
     RatingUpdate,
     RecipeModelResponse,
     RecipePrompt,
+    RecipeUpdateRequest,
 )
 from tools import find_similar_ingredients
 
@@ -224,6 +226,64 @@ async def update_rating(recipe_id: PydanticObjectId, body: RatingUpdate):
     return {"id": str(recipe.id), "rating": recipe.rating}
 
 
+@router.put("/recipes/{recipe_id}")
+async def update_recipe(recipe_id: PydanticObjectId, body: RecipeUpdateRequest):
+    recipe = await RecipeDocument.get(recipe_id)
+    if not recipe:
+        raise HTTPException(status_code=404, detail="Recipe not found")
+
+    old_names = {i.name.lower() for i in recipe.ingredients}
+    recipe.title = body.title
+    recipe.instructions = body.instructions
+    recipe.ingredients = body.ingredients
+    await recipe.save()
+
+    # Fire-and-forget: embed any new ingredient names
+    new_ingredients = [i for i in body.ingredients if i.name.lower() not in old_names]
+    if new_ingredients:
+        async def _embed_new():
+            try:
+                vectors = vo.embed(
+                    texts=[i.name for i in new_ingredients],
+                    model="voyage-4",
+                    output_dimension=2048,
+                ).embeddings
+                await IngredientDocument.insert_many([
+                    IngredientDocument(
+                        name=item.name, unit=item.unit, embedding=vectors[idx],
+                        category=item.category,
+                    )
+                    for idx, item in enumerate(new_ingredients)
+                ])
+            except Exception:
+                pass  # Best-effort background embedding
+        asyncio.create_task(_embed_new())
+
+    return recipe
+
+
+@router.delete("/recipes/{recipe_id}", status_code=204)
+async def delete_recipe(recipe_id: PydanticObjectId):
+    recipe = await RecipeDocument.get(recipe_id)
+    if not recipe:
+        raise HTTPException(status_code=404, detail="Recipe not found")
+    await recipe.delete()
+
+
+@router.patch("/recipes/{recipe_id}/ingredients/{ingredient_index}/exclude")
+async def toggle_ingredient_exclude(
+    recipe_id: PydanticObjectId, ingredient_index: int, body: ExcludeUpdateRequest
+):
+    recipe = await RecipeDocument.get(recipe_id)
+    if not recipe:
+        raise HTTPException(status_code=404, detail="Recipe not found")
+    if ingredient_index < 0 or ingredient_index >= len(recipe.ingredients):
+        raise HTTPException(status_code=404, detail="Ingredient not found")
+    recipe.ingredients[ingredient_index].excluded_from_list = body.excluded
+    await recipe.save()
+    return {"index": ingredient_index, "excluded_from_list": body.excluded}
+
+
 @router.get("/units")
 async def get_units():
     pipeline = [
@@ -421,8 +481,10 @@ async def add_recipe_to_list(list_id: PydanticObjectId, body: AddRecipeRequest):
 
     lst.recipes.append(body.recipe_id)
 
-    # Merge recipe ingredients into list items
+    # Merge recipe ingredients into list items (skip excluded)
     for ing in recipe.ingredients:
+        if ing.excluded_from_list:
+            continue
         source = ItemSource(recipe_id=body.recipe_id, amount=ing.amount)
         # Find existing item with same name + unit (case-insensitive name, exact unit)
         matched = None


### PR DESCRIPTION
## Summary
- Full recipe editing (title, instructions, ingredients) via inline edit mode
- Per-ingredient `excluded_from_list` flag to skip items when adding to shopping lists
- Recipe deletion with confirmation
- Background Voyage AI embedding for new ingredients (no latency impact)

Closes #39

## Test plan
- [ ] Edit a recipe (title, ingredients, instructions) and verify persistence
- [ ] Add/remove/reorder ingredients and instructions
- [ ] Toggle ingredient exclusion and verify it persists
- [ ] Add recipe to list — verify excluded ingredients are skipped
- [ ] Delete a recipe and verify redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)