### PR TITLE
Keep screen on while viewing a recipe

### DIFF
--- a/client/src/hooks/useWakeLock.ts
+++ b/client/src/hooks/useWakeLock.ts
@@ -1,0 +1,45 @@
+import { useEffect } from 'react'
+
+export function useWakeLock(enabled: boolean = true) {
+  useEffect(() => {
+    if (!enabled) return
+    if (typeof navigator === 'undefined' || !('wakeLock' in navigator)) return
+
+    let sentinel: WakeLockSentinel | null = null
+    let cancelled = false
+
+    const request = async () => {
+      try {
+        const lock = await navigator.wakeLock.request('screen')
+        if (cancelled) {
+          lock.release().catch(() => {})
+          return
+        }
+        sentinel = lock
+        lock.addEventListener('release', () => {
+          if (sentinel === lock) sentinel = null
+        })
+      } catch {
+        // User may have denied, battery saver on, etc. — silently ignore.
+      }
+    }
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible' && sentinel === null) {
+        request()
+      }
+    }
+
+    request()
+    document.addEventListener('visibilitychange', onVisibilityChange)
+
+    return () => {
+      cancelled = true
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+      if (sentinel) {
+        sentinel.release().catch(() => {})
+        sentinel = null
+      }
+    }
+  }, [enabled])
+}

--- a/client/src/routes/recipe.$recipeId.tsx
+++ b/client/src/routes/recipe.$recipeId.tsx
@@ -7,6 +7,7 @@ import { apiFetch } from '@/lib/api'
 import { RecipeCard } from '@/components/RecipeCard'
 import { StarRating } from '@/components/StarRating'
 import type { Recipe } from '@/components/RecipeCard'
+import { useWakeLock } from '@/hooks/useWakeLock'
 import '@/index.css'
 
 type RecipeDetail = Recipe & {
@@ -28,6 +29,8 @@ function RecipeDetailPage() {
   const { recipeId } = Route.useParams()
   const queryClient = useQueryClient()
   const [addedToList, setAddedToList] = useState<string | null>(null)
+
+  useWakeLock()
 
   const { data: recipe, isLoading } = useQuery({
     queryKey: ['recipe', recipeId],


### PR DESCRIPTION
Uses the Screen Wake Lock API so phones don't dim or lock while
someone is reading a recipe mid-cook. Re-acquires the lock on
visibilitychange since the browser releases it when the tab hides.