### PR TITLE
Add list/grid view toggle for recipes

### DIFF
--- a/client/src/routes/recipes.tsx
+++ b/client/src/routes/recipes.tsx
@@ -1,8 +1,11 @@
+import { useEffect, useState } from 'react'
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { Loader2 } from 'lucide-react'
+import { LayoutGrid, List, Loader2 } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
 import { StarRating } from '@/components/StarRating'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 import '@/index.css'
 
 type RecipeSummary = {
@@ -13,10 +16,26 @@ type RecipeSummary = {
   created_at: string | null
 }
 
+type ViewMode = 'list' | 'grid'
+
+const VIEW_STORAGE_KEY = 'recipes-view'
+
+function getInitialView(): ViewMode {
+  if (typeof window === 'undefined') return 'list'
+  return window.localStorage.getItem(VIEW_STORAGE_KEY) === 'grid'
+    ? 'grid'
+    : 'list'
+}
+
 export const Route = createFileRoute('/recipes')({ component: RecipeList })
 
 function RecipeList() {
   const queryClient = useQueryClient()
+  const [view, setView] = useState<ViewMode>(getInitialView)
+
+  useEffect(() => {
+    window.localStorage.setItem(VIEW_STORAGE_KEY, view)
+  }, [view])
 
   const { data: recipes, isLoading } = useQuery({
     queryKey: ['recipes'],
@@ -40,10 +59,47 @@ function RecipeList() {
     },
   })
 
+  const rateRecipe = (id: string, rating: number) =>
+    ratingMutation.mutate({ id, rating })
+
   return (
     <div className="min-h-screen bg-linear-to-b from-slate-900 via-slate-800 to-slate-900 text-white">
-      <div className="max-w-2xl mx-auto px-4 py-12">
-        <h1 className="text-2xl font-bold tracking-tight mb-8">My Recipes</h1>
+      <div className="max-w-5xl mx-auto px-4 py-12">
+        <div className="flex items-center justify-between mb-8">
+          <h1 className="text-2xl font-bold tracking-tight">My Recipes</h1>
+          {recipes && recipes.length > 0 && (
+            <div className="flex items-center gap-1 rounded-lg border border-slate-700 bg-slate-800 p-1">
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                aria-label="List view"
+                aria-pressed={view === 'list'}
+                onClick={() => setView('list')}
+                className={cn(
+                  'text-slate-400 hover:text-white',
+                  view === 'list' && 'bg-slate-700 text-white',
+                )}
+              >
+                <List />
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                aria-label="Grid view"
+                aria-pressed={view === 'grid'}
+                onClick={() => setView('grid')}
+                className={cn(
+                  'text-slate-400 hover:text-white',
+                  view === 'grid' && 'bg-slate-700 text-white',
+                )}
+              >
+                <LayoutGrid />
+              </Button>
+            </div>
+          )}
+        </div>
 
         {isLoading && (
           <div className="flex items-center gap-2 text-slate-400">
@@ -64,42 +120,94 @@ function RecipeList() {
           </div>
         )}
 
-        {recipes && recipes.length > 0 && (
+        {recipes && recipes.length > 0 && view === 'list' && (
           <div className="space-y-3">
             {recipes.map((recipe) => (
-              <div
+              <RecipeListRow
                 key={recipe.id}
-                className="bg-slate-800 border border-slate-700 rounded-xl p-5 flex items-center gap-4"
-              >
-                <div className="flex-1 min-w-0">
-                  <Link
-                    to="/recipe/$recipeId"
-                    params={{ recipeId: recipe.id }}
-                    className="text-white font-medium hover:underline underline-offset-4"
-                  >
-                    {recipe.title}
-                  </Link>
-                  <div className="flex items-center gap-3 mt-1.5 text-sm text-slate-400">
-                    <span>{recipe.ingredient_count} ingredient{recipe.ingredient_count !== 1 ? 's' : ''}</span>
-                    <span className="text-slate-600">·</span>
-                    <span>
-                      {recipe.created_at
-                        ? new Date(recipe.created_at).toLocaleDateString()
-                        : 'Unknown date'}
-                    </span>
-                  </div>
-                </div>
-                <StarRating
-                  value={recipe.rating}
-                  onChange={(rating) =>
-                    ratingMutation.mutate({ id: recipe.id, rating })
-                  }
-                />
-              </div>
+                recipe={recipe}
+                onRate={rateRecipe}
+              />
+            ))}
+          </div>
+        )}
+
+        {recipes && recipes.length > 0 && view === 'grid' && (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {recipes.map((recipe) => (
+              <RecipeGridCard
+                key={recipe.id}
+                recipe={recipe}
+                onRate={rateRecipe}
+              />
             ))}
           </div>
         )}
       </div>
+    </div>
+  )
+}
+
+function RecipeMeta({ recipe }: { recipe: RecipeSummary }) {
+  return (
+    <div className="flex items-center gap-3 mt-1.5 text-sm text-slate-400">
+      <span>
+        {recipe.ingredient_count} ingredient
+        {recipe.ingredient_count !== 1 ? 's' : ''}
+      </span>
+      <span className="text-slate-600">·</span>
+      <span>
+        {recipe.created_at
+          ? new Date(recipe.created_at).toLocaleDateString()
+          : 'Unknown date'}
+      </span>
+    </div>
+  )
+}
+
+type RecipeItemProps = {
+  recipe: RecipeSummary
+  onRate: (id: string, rating: number) => void
+}
+
+function RecipeListRow({ recipe, onRate }: RecipeItemProps) {
+  return (
+    <div className="bg-slate-800 border border-slate-700 rounded-xl p-5 flex items-center gap-4">
+      <div className="flex-1 min-w-0">
+        <Link
+          to="/recipe/$recipeId"
+          params={{ recipeId: recipe.id }}
+          className="text-white font-medium hover:underline underline-offset-4"
+        >
+          {recipe.title}
+        </Link>
+        <RecipeMeta recipe={recipe} />
+      </div>
+      <StarRating
+        value={recipe.rating}
+        onChange={(rating) => onRate(recipe.id, rating)}
+      />
+    </div>
+  )
+}
+
+function RecipeGridCard({ recipe, onRate }: RecipeItemProps) {
+  return (
+    <div className="bg-slate-800 border border-slate-700 rounded-xl p-5 flex flex-col gap-4 h-full">
+      <div className="flex-1 min-w-0">
+        <Link
+          to="/recipe/$recipeId"
+          params={{ recipeId: recipe.id }}
+          className="text-white font-medium hover:underline underline-offset-4"
+        >
+          {recipe.title}
+        </Link>
+        <RecipeMeta recipe={recipe} />
+      </div>
+      <StarRating
+        value={recipe.rating}
+        onChange={(rating) => onRate(recipe.id, rating)}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
Added a view mode toggle to the recipes page, allowing users to switch between list and grid layouts. The selected view preference is persisted to localStorage.

## Key Changes
- **View mode toggle UI**: Added buttons in the header to switch between list and grid views, with visual feedback for the active mode
- **State management**: Implemented `view` state with localStorage persistence using `getInitialView()` helper to restore user preference on page load
- **Layout refactoring**: Extracted recipe display logic into reusable components:
  - `RecipeListRow` — horizontal card layout for list view
  - `RecipeGridCard` — vertical card layout for grid view (3-column responsive grid)
  - `RecipeMeta` — shared metadata display component
- **Container width**: Increased max-width from `2xl` to `5xl` to better utilize space in grid view
- **Accessibility**: Added proper ARIA labels and `aria-pressed` attributes to view toggle buttons

## Implementation Details
- View preference stored in localStorage under key `recipes-view`
- Grid layout uses responsive columns: 1 on mobile, 2 on tablets, 3 on desktop
- View toggle only displays when recipes are available
- Both layouts maintain consistent styling and functionality (star ratings, links, metadata)

https://claude.ai/code/session_019wWYa2wr2DxDRy2kLqckH3