### PR TITLE
Retheme UI from dark slate to warm cream + amber

### DIFF
--- a/client/src/components/RecipeCard.tsx
+++ b/client/src/components/RecipeCard.tsx
@@ -5,18 +5,18 @@ export type Recipe = { title: string; instructions: string[]; ingredients: Ingre
 
 export function RecipeCard({ recipe }: { recipe: Recipe }) {
   return (
-    <div className="bg-white border border-[#E8E4DC] rounded-xl p-6 space-y-5 shadow-sm">
-      <h2 className="text-xl font-semibold text-[#222]">{recipe.title}</h2>
+    <div className="bg-white border border-line rounded-xl p-6 space-y-5 shadow-sm">
+      <h2 className="text-xl font-semibold text-ink">{recipe.title}</h2>
 
       <div>
-        <h3 className="text-xs font-semibold text-[#8E8E8E] uppercase tracking-wider mb-3">
+        <h3 className="text-xs font-semibold text-ink-muted uppercase tracking-wider mb-3">
           Ingredients
         </h3>
         <ul className="space-y-1.5">
           {recipe.ingredients.map((ing, i) => (
-            <li key={i} className="text-sm text-[#444] flex gap-2">
+            <li key={i} className="text-sm text-ink-soft flex gap-2">
               <span className="flex-1">{ing.name}</span>
-              <span className="text-[#222] font-medium shrink-0">
+              <span className="text-ink font-medium shrink-0">
                 {ing.amount} {ing.unit}
               </span>
             </li>
@@ -25,13 +25,13 @@ export function RecipeCard({ recipe }: { recipe: Recipe }) {
       </div>
 
       <div>
-        <h3 className="text-xs font-semibold text-[#8E8E8E] uppercase tracking-wider mb-3">
+        <h3 className="text-xs font-semibold text-ink-muted uppercase tracking-wider mb-3">
           Instructions
         </h3>
         <ol className="space-y-2.5">
           {recipe.instructions.map((step, i) => (
-            <li key={i} className="text-sm text-[#444] flex gap-3">
-              <span className="text-[#ADADAD] font-mono shrink-0 pt-px">{i + 1}.</span>
+            <li key={i} className="text-sm text-ink-soft flex gap-3">
+              <span className="text-ink-faint font-mono shrink-0 pt-px">{i + 1}.</span>
               <span>{highlightAmounts(step)}</span>
             </li>
           ))}

--- a/client/src/components/RecipeCard.tsx
+++ b/client/src/components/RecipeCard.tsx
@@ -5,18 +5,18 @@ export type Recipe = { title: string; instructions: string[]; ingredients: Ingre
 
 export function RecipeCard({ recipe }: { recipe: Recipe }) {
   return (
-    <div className="bg-slate-800 border border-slate-700 rounded-xl p-6 space-y-5">
-      <h2 className="text-xl font-semibold text-white">{recipe.title}</h2>
+    <div className="bg-white border border-[#E8E4DC] rounded-xl p-6 space-y-5 shadow-sm">
+      <h2 className="text-xl font-semibold text-[#222]">{recipe.title}</h2>
 
       <div>
-        <h3 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-3">
+        <h3 className="text-xs font-semibold text-[#8E8E8E] uppercase tracking-wider mb-3">
           Ingredients
         </h3>
         <ul className="space-y-1.5">
           {recipe.ingredients.map((ing, i) => (
-            <li key={i} className="text-sm text-slate-300 flex gap-2">
+            <li key={i} className="text-sm text-[#444] flex gap-2">
               <span className="flex-1">{ing.name}</span>
-              <span className="text-white font-medium shrink-0">
+              <span className="text-[#222] font-medium shrink-0">
                 {ing.amount} {ing.unit}
               </span>
             </li>
@@ -25,13 +25,13 @@ export function RecipeCard({ recipe }: { recipe: Recipe }) {
       </div>
 
       <div>
-        <h3 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-3">
+        <h3 className="text-xs font-semibold text-[#8E8E8E] uppercase tracking-wider mb-3">
           Instructions
         </h3>
         <ol className="space-y-2.5">
           {recipe.instructions.map((step, i) => (
-            <li key={i} className="text-sm text-slate-300 flex gap-3">
-              <span className="text-slate-500 font-mono shrink-0 pt-px">{i + 1}.</span>
+            <li key={i} className="text-sm text-[#444] flex gap-3">
+              <span className="text-[#ADADAD] font-mono shrink-0 pt-px">{i + 1}.</span>
               <span>{highlightAmounts(step)}</span>
             </li>
           ))}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;0,9..40,800&display=swap');
 @import 'tailwindcss';
 @import 'tw-animate-css';
 @import 'shadcn/tailwind.css';
@@ -47,37 +48,37 @@
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
+  --background: oklch(0.99 0.006 90);
+  --foreground: oklch(0.18 0 0);
   --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
+  --card-foreground: oklch(0.18 0 0);
   --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.18 0 0);
+  --primary: oklch(0.82 0.165 76);
+  --primary-foreground: oklch(0.18 0 0);
+  --secondary: oklch(0.95 0.008 82);
+  --secondary-foreground: oklch(0.18 0 0);
+  --muted: oklch(0.97 0.002 80);
+  --muted-foreground: oklch(0.6 0 0);
+  --accent: oklch(0.94 0.008 82);
+  --accent-foreground: oklch(0.18 0 0);
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
+  --border: oklch(0.92 0.008 80);
+  --input: oklch(0.92 0.008 80);
+  --ring: oklch(0.82 0.165 76);
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --sidebar: oklch(0.99 0.006 90);
+  --sidebar-foreground: oklch(0.18 0 0);
+  --sidebar-primary: oklch(0.82 0.165 76);
+  --sidebar-primary-foreground: oklch(0.18 0 0);
+  --sidebar-accent: oklch(0.94 0.008 82);
+  --sidebar-accent-foreground: oklch(0.18 0 0);
+  --sidebar-border: oklch(0.92 0.008 80);
+  --sidebar-ring: oklch(0.82 0.165 76);
 }
 
 .dark {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -44,6 +44,19 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+
+  /* Omlete warm cream + amber palette */
+  --color-cream: #f4f4f4; /* page background */
+  --color-sand: #f0ede6; /* warm hover / active surface */
+  --color-linen: #fafaf8; /* sidebar surface */
+  --color-mist: #efefef; /* tab track */
+  --color-ink: #222222; /* primary text */
+  --color-ink-soft: #444444; /* body text */
+  --color-ink-muted: #8e8e8e; /* muted labels */
+  --color-ink-faint: #adadad; /* placeholders, step numbers */
+  --color-ink-subtle: #cfcfcf; /* faint icons */
+  --color-line: #e8e4dc; /* borders */
+  --color-line-strong: #e0dace; /* nested input borders */
 }
 
 :root {

--- a/client/src/lib/highlightAmounts.tsx
+++ b/client/src/lib/highlightAmounts.tsx
@@ -5,7 +5,7 @@ export function highlightAmounts(text: string) {
   if (parts.length === 1) return text
   return parts.map((part, i) =>
     AMOUNT_RE.test(part) ? (
-      <span key={i} className="text-white font-medium">{part}</span>
+      <span key={i} className="text-[#222] font-semibold">{part}</span>
     ) : (
       part
     )

--- a/client/src/lib/highlightAmounts.tsx
+++ b/client/src/lib/highlightAmounts.tsx
@@ -5,7 +5,7 @@ export function highlightAmounts(text: string) {
   if (parts.length === 1) return text
   return parts.map((part, i) =>
     AMOUNT_RE.test(part) ? (
-      <span key={i} className="text-[#222] font-semibold">{part}</span>
+      <span key={i} className="text-ink font-semibold">{part}</span>
     ) : (
       part
     )

--- a/client/src/routes/__root.tsx
+++ b/client/src/routes/__root.tsx
@@ -60,6 +60,8 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
       },
     ],
     links: [
+      { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
+      { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;0,9..40,800&display=swap' },
       { rel: 'manifest', href: '/manifest.webmanifest' },
       { rel: 'icon', href: '/favicon.ico', sizes: 'any' },
       { rel: 'icon', type: 'image/svg+xml', href: '/icon.svg' },
@@ -72,20 +74,20 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
 function NavBar() {
   const linkClass =
     'px-3 py-2 rounded-md text-sm font-medium transition-colors min-h-[44px] flex items-center'
-  const activeClass = 'text-white bg-slate-700'
-  const inactiveClass = 'text-slate-400 hover:text-slate-200'
+  const activeClass = 'text-[#222] bg-[#F0EDE6]'
+  const inactiveClass = 'text-[#8E8E8E] hover:text-[#222]'
 
   const mobileLinkClass =
     'flex flex-col items-center justify-center gap-1 text-xs font-medium transition-colors min-h-[44px] flex-1'
-  const mobileActiveClass = 'text-white'
-  const mobileInactiveClass = 'text-slate-500'
+  const mobileActiveClass = 'text-[#FFB951]'
+  const mobileInactiveClass = 'text-[#8E8E8E]'
 
   return (
     <>
       {/* Desktop top nav */}
-      <nav className="hidden sm:block bg-slate-900 border-b border-slate-800">
+      <nav className="hidden sm:block bg-white border-b border-[#E8E4DC]">
         <div className="max-w-2xl mx-auto px-4 flex items-center gap-6 h-14">
-          <Link to="/" className="text-xl font-bold tracking-tight text-white mr-4">
+          <Link to="/" className="text-xl font-bold tracking-tight text-[#222] mr-4" style={{fontFamily:'DM Sans'}}>
             Omlete
           </Link>
           <Link
@@ -126,7 +128,7 @@ function NavBar() {
       </nav>
 
       {/* Mobile bottom tab bar */}
-      <nav className="sm:hidden fixed bottom-0 left-0 right-0 z-50 bg-slate-900 border-t border-slate-800 safe-area-bottom">
+      <nav className="sm:hidden fixed bottom-0 left-0 right-0 z-50 bg-white border-t border-[#E8E4DC] safe-area-bottom">
         <div className="flex items-center h-14">
           <Link
             to="/"
@@ -173,11 +175,11 @@ function NavBar() {
 
 function RootDocument({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className="dark">
+    <html lang="en">
       <head>
         <HeadContent />
       </head>
-      <body className="bg-slate-900 pb-16 sm:pb-0">
+      <body className="pb-16 sm:pb-0">
         <TanStackQueryProvider>
           <NavBar />
           {children}

--- a/client/src/routes/__root.tsx
+++ b/client/src/routes/__root.tsx
@@ -36,7 +36,7 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
       },
       {
         name: 'theme-color',
-        content: '#0f172a',
+        content: '#f4f4f4',
       },
       {
         name: 'application-name',
@@ -74,20 +74,20 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
 function NavBar() {
   const linkClass =
     'px-3 py-2 rounded-md text-sm font-medium transition-colors min-h-[44px] flex items-center'
-  const activeClass = 'text-[#222] bg-[#F0EDE6]'
-  const inactiveClass = 'text-[#8E8E8E] hover:text-[#222]'
+  const activeClass = 'text-ink bg-sand'
+  const inactiveClass = 'text-ink-muted hover:text-ink'
 
   const mobileLinkClass =
     'flex flex-col items-center justify-center gap-1 text-xs font-medium transition-colors min-h-[44px] flex-1'
-  const mobileActiveClass = 'text-[#FFB951]'
-  const mobileInactiveClass = 'text-[#8E8E8E]'
+  const mobileActiveClass = 'text-primary'
+  const mobileInactiveClass = 'text-ink-muted'
 
   return (
     <>
       {/* Desktop top nav */}
-      <nav className="hidden sm:block bg-white border-b border-[#E8E4DC]">
+      <nav className="hidden sm:block bg-white border-b border-line">
         <div className="max-w-2xl mx-auto px-4 flex items-center gap-6 h-14">
-          <Link to="/" className="text-xl font-bold tracking-tight text-[#222] mr-4" style={{fontFamily:'DM Sans'}}>
+          <Link to="/" className="text-xl font-bold tracking-tight text-ink mr-4" style={{fontFamily:'DM Sans'}}>
             Omlete
           </Link>
           <Link
@@ -128,7 +128,7 @@ function NavBar() {
       </nav>
 
       {/* Mobile bottom tab bar */}
-      <nav className="sm:hidden fixed bottom-0 left-0 right-0 z-50 bg-white border-t border-[#E8E4DC] safe-area-bottom">
+      <nav className="sm:hidden fixed bottom-0 left-0 right-0 z-50 bg-white border-t border-line safe-area-bottom">
         <div className="flex items-center h-14">
           <Link
             to="/"

--- a/client/src/routes/create.tsx
+++ b/client/src/routes/create.tsx
@@ -16,19 +16,19 @@ function CreatePage() {
   const [tab, setTab] = useState<Tab>('extract')
 
   return (
-    <div className="min-h-screen bg-[#F4F4F4] text-[#222]">
+    <div className="min-h-screen bg-cream text-ink">
       <div className="max-w-2xl mx-auto px-4 py-12">
         <h1 className="text-2xl font-bold mb-2">Create Recipe</h1>
-        <p className="text-[#8E8E8E] mb-8">Generate or extract recipes with AI</p>
+        <p className="text-ink-muted mb-8">Generate or extract recipes with AI</p>
 
-        <div className="flex gap-1 p-1 bg-[#EFEFEF] rounded-lg mb-8 w-fit">
+        <div className="flex gap-1 p-1 bg-mist rounded-lg mb-8 w-fit">
           {(['generate', 'extract'] as const).map((t) => (
             <button
               key={t}
               onClick={() => setTab(t)}
               className={`px-4 py-2 rounded-md text-sm font-medium transition-colors cursor-pointer ${tab === t
-                  ? 'bg-white text-[#222] shadow-sm'
-                  : 'text-[#8E8E8E] hover:text-[#444]'
+                  ? 'bg-white text-ink shadow-sm'
+                  : 'text-ink-muted hover:text-ink-soft'
                 }`}
             >
               {t === 'generate' ? 'Generate' : 'Extract from Images'}
@@ -59,7 +59,7 @@ function GenerateTab() {
   return (
     <div className="space-y-6">
       <div className="space-y-2">
-        <label className="text-sm font-medium text-[#444]">
+        <label className="text-sm font-medium text-ink-soft">
           What ingredients do you have?
         </label>
         <textarea
@@ -67,7 +67,7 @@ function GenerateTab() {
           onChange={(e) => setPrompt(e.target.value)}
           placeholder="e.g. eggs, crème fraîche, salt, pepper, chives..."
           rows={3}
-          className="w-full bg-white border border-[#E8E4DC] rounded-lg px-4 py-3 text-sm text-[#222] placeholder-[#ADADAD] focus:outline-none focus:ring-2 focus:ring-[#FFB951] resize-none"
+          className="w-full bg-white border border-line rounded-lg px-4 py-3 text-sm text-ink placeholder-ink-faint focus:outline-none focus:ring-2 focus:ring-primary resize-none"
         />
       </div>
 
@@ -171,7 +171,7 @@ function ExtractTab() {
       <button
         onClick={addGroup}
         disabled={isExtracting}
-        className="w-full border-2 border-dashed border-[#E8E4DC] rounded-xl p-6 flex items-center justify-center gap-2 text-[#8E8E8E] hover:border-[#FFB951] hover:text-[#444] transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+        className="w-full border-2 border-dashed border-line rounded-xl p-6 flex items-center justify-center gap-2 text-ink-muted hover:border-primary hover:text-ink-soft transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
       >
         <Plus className="size-5" />
         <span className="text-sm font-medium">Add Recipe</span>
@@ -198,7 +198,7 @@ function ExtractTab() {
       {/* Results */}
       {results.length > 0 && (
         <div className="space-y-4">
-          <h3 className="text-sm font-medium text-[#8E8E8E]">
+          <h3 className="text-sm font-medium text-ink-muted">
             Extracted {results.length} recipe{results.length !== 1 ? 's' : ''}
           </h3>
           {results.map((recipe, i) => (
@@ -228,7 +228,7 @@ function RecipeGroupRow({
   const inputRef = useRef<HTMLInputElement>(null)
 
   return (
-    <div className="bg-white border border-[#E8E4DC] rounded-lg p-4 space-y-3 shadow-sm">
+    <div className="bg-white border border-line rounded-lg p-4 space-y-3 shadow-sm">
       <div className="flex items-center justify-between">
         <h3 className="text-sm font-medium">Recipe {index + 1}</h3>
         <Button
@@ -248,14 +248,14 @@ function RecipeGroupRow({
           {group.files.map((f, i) => (
             <div
               key={i}
-              className="relative group bg-[#F4F4F4] rounded-md px-3 py-2 flex items-center gap-2"
+              className="relative group bg-cream rounded-md px-3 py-2 flex items-center gap-2"
             >
-              <ImageIcon className="size-4 text-[#8E8E8E] shrink-0" />
-              <span className="text-xs text-[#444] truncate max-w-[120px]">{f.name}</span>
+              <ImageIcon className="size-4 text-ink-muted shrink-0" />
+              <span className="text-xs text-ink-soft truncate max-w-[120px]">{f.name}</span>
               <button
                 onClick={() => onRemoveFile(i)}
                 disabled={disabled}
-                className="text-[#ADADAD] hover:text-[#8E8E8E] cursor-pointer"
+                className="text-ink-faint hover:text-ink-muted cursor-pointer"
               >
                 <X className="size-3.5" />
               </button>
@@ -279,7 +279,7 @@ function RecipeGroupRow({
       <button
         onClick={() => inputRef.current?.click()}
         disabled={disabled}
-        className="flex items-center gap-2 text-sm text-[#8E8E8E] hover:text-[#444] transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+        className="flex items-center gap-2 text-sm text-ink-muted hover:text-ink-soft transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
       >
         <UploadCloud className="size-4" />
         Add photos

--- a/client/src/routes/create.tsx
+++ b/client/src/routes/create.tsx
@@ -16,19 +16,19 @@ function CreatePage() {
   const [tab, setTab] = useState<Tab>('extract')
 
   return (
-    <div className="min-h-screen bg-linear-to-b from-slate-900 via-slate-800 to-slate-900 text-white">
+    <div className="min-h-screen bg-[#F4F4F4] text-[#222]">
       <div className="max-w-2xl mx-auto px-4 py-12">
         <h1 className="text-2xl font-bold mb-2">Create Recipe</h1>
-        <p className="text-slate-400 mb-8">Generate or extract recipes with AI</p>
+        <p className="text-[#8E8E8E] mb-8">Generate or extract recipes with AI</p>
 
-        <div className="flex gap-1 p-1 bg-slate-800 rounded-lg mb-8 w-fit">
+        <div className="flex gap-1 p-1 bg-[#EFEFEF] rounded-lg mb-8 w-fit">
           {(['generate', 'extract'] as const).map((t) => (
             <button
               key={t}
               onClick={() => setTab(t)}
               className={`px-4 py-2 rounded-md text-sm font-medium transition-colors cursor-pointer ${tab === t
-                  ? 'bg-slate-700 text-white shadow-sm'
-                  : 'text-slate-400 hover:text-slate-200'
+                  ? 'bg-white text-[#222] shadow-sm'
+                  : 'text-[#8E8E8E] hover:text-[#444]'
                 }`}
             >
               {t === 'generate' ? 'Generate' : 'Extract from Images'}
@@ -59,7 +59,7 @@ function GenerateTab() {
   return (
     <div className="space-y-6">
       <div className="space-y-2">
-        <label className="text-sm font-medium text-slate-300">
+        <label className="text-sm font-medium text-[#444]">
           What ingredients do you have?
         </label>
         <textarea
@@ -67,7 +67,7 @@ function GenerateTab() {
           onChange={(e) => setPrompt(e.target.value)}
           placeholder="e.g. eggs, crème fraîche, salt, pepper, chives..."
           rows={3}
-          className="w-full bg-slate-800 border border-slate-700 rounded-lg px-4 py-3 text-sm text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-500 resize-none"
+          className="w-full bg-white border border-[#E8E4DC] rounded-lg px-4 py-3 text-sm text-[#222] placeholder-[#ADADAD] focus:outline-none focus:ring-2 focus:ring-[#FFB951] resize-none"
         />
       </div>
 
@@ -171,7 +171,7 @@ function ExtractTab() {
       <button
         onClick={addGroup}
         disabled={isExtracting}
-        className="w-full border-2 border-dashed border-slate-700 rounded-xl p-6 flex items-center justify-center gap-2 text-slate-400 hover:border-slate-500 hover:text-slate-300 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+        className="w-full border-2 border-dashed border-[#E8E4DC] rounded-xl p-6 flex items-center justify-center gap-2 text-[#8E8E8E] hover:border-[#FFB951] hover:text-[#444] transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
       >
         <Plus className="size-5" />
         <span className="text-sm font-medium">Add Recipe</span>
@@ -198,7 +198,7 @@ function ExtractTab() {
       {/* Results */}
       {results.length > 0 && (
         <div className="space-y-4">
-          <h3 className="text-sm font-medium text-slate-400">
+          <h3 className="text-sm font-medium text-[#8E8E8E]">
             Extracted {results.length} recipe{results.length !== 1 ? 's' : ''}
           </h3>
           {results.map((recipe, i) => (
@@ -228,7 +228,7 @@ function RecipeGroupRow({
   const inputRef = useRef<HTMLInputElement>(null)
 
   return (
-    <div className="bg-slate-800 border border-slate-700 rounded-lg p-4 space-y-3">
+    <div className="bg-white border border-[#E8E4DC] rounded-lg p-4 space-y-3 shadow-sm">
       <div className="flex items-center justify-between">
         <h3 className="text-sm font-medium">Recipe {index + 1}</h3>
         <Button
@@ -248,14 +248,14 @@ function RecipeGroupRow({
           {group.files.map((f, i) => (
             <div
               key={i}
-              className="relative group bg-slate-700 rounded-md px-3 py-2 flex items-center gap-2"
+              className="relative group bg-[#F4F4F4] rounded-md px-3 py-2 flex items-center gap-2"
             >
-              <ImageIcon className="size-4 text-slate-400 shrink-0" />
-              <span className="text-xs text-slate-300 truncate max-w-[120px]">{f.name}</span>
+              <ImageIcon className="size-4 text-[#8E8E8E] shrink-0" />
+              <span className="text-xs text-[#444] truncate max-w-[120px]">{f.name}</span>
               <button
                 onClick={() => onRemoveFile(i)}
                 disabled={disabled}
-                className="text-slate-500 hover:text-slate-300 cursor-pointer"
+                className="text-[#ADADAD] hover:text-[#8E8E8E] cursor-pointer"
               >
                 <X className="size-3.5" />
               </button>
@@ -279,7 +279,7 @@ function RecipeGroupRow({
       <button
         onClick={() => inputRef.current?.click()}
         disabled={disabled}
-        className="flex items-center gap-2 text-sm text-slate-400 hover:text-slate-200 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+        className="flex items-center gap-2 text-sm text-[#8E8E8E] hover:text-[#444] transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
       >
         <UploadCloud className="size-4" />
         Add photos

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -59,7 +59,7 @@ function ListsPage() {
   })
 
   return (
-    <div className="min-h-screen bg-[#F4F4F4] text-[#222]">
+    <div className="min-h-screen bg-cream text-ink">
       <div className="max-w-2xl mx-auto px-4 py-12">
         <div className="flex items-center justify-between mb-8">
           <h1 className="text-2xl font-bold">My Lists</h1>
@@ -77,14 +77,14 @@ function ListsPage() {
 
         {isLoading && (
           <div className="flex justify-center py-12">
-            <Loader2 className="size-6 animate-spin text-[#8E8E8E]" />
+            <Loader2 className="size-6 animate-spin text-ink-muted" />
           </div>
         )}
 
         {lists && lists.length === 0 && (
           <div className="text-center py-16">
-            <ShoppingCart className="size-12 mx-auto text-[#CFCFCF] mb-4" />
-            <p className="text-[#8E8E8E] mb-4">No shopping lists yet</p>
+            <ShoppingCart className="size-12 mx-auto text-ink-subtle mb-4" />
+            <p className="text-ink-muted mb-4">No shopping lists yet</p>
             <Button onClick={() => createList.mutate()} disabled={createList.isPending}>
               <Plus className="size-4" />
               Create your first list
@@ -98,34 +98,34 @@ function ListsPage() {
               <button
                 key={list.id}
                 onClick={() => navigate({ to: '/list/$listId', params: { listId: list.id } })}
-                className="w-full text-left bg-white border border-[#E8E4DC] rounded-lg p-4 shadow-sm hover:shadow-md hover:border-[#FFB951] transition-all cursor-pointer"
+                className="w-full text-left bg-white border border-line rounded-lg p-4 shadow-sm hover:shadow-md hover:border-primary transition-all cursor-pointer"
               >
                 <div className="flex items-center justify-between mb-1">
                   <h2 className="font-medium">{list.name}</h2>
-                  <span className="text-sm text-[#8E8E8E]">
+                  <span className="text-sm text-ink-muted">
                     {list.checked_count}/{list.item_count} items
                   </span>
                 </div>
 
                 {/* Progress bar */}
                 {list.item_count > 0 && (
-                  <div className="w-full h-1.5 bg-[#E8E4DC] rounded-full mb-2">
+                  <div className="w-full h-1.5 bg-line rounded-full mb-2">
                     <div
-                      className="h-full bg-[#FFB951] rounded-full transition-all"
+                      className="h-full bg-primary rounded-full transition-all"
                       style={{ width: `${(list.checked_count / list.item_count) * 100}%` }}
                     />
                   </div>
                 )}
 
                 {list.recipe_titles.length > 0 && (
-                  <p className="text-sm text-[#8E8E8E] truncate">
+                  <p className="text-sm text-ink-muted truncate">
                     {list.recipe_titles.join(', ')}
                   </p>
                 )}
 
                 <div className="flex items-center justify-between mt-2">
                   {list.created_at && (
-                    <p className="text-xs text-[#ADADAD]">
+                    <p className="text-xs text-ink-faint">
                       {new Date(list.created_at).toLocaleDateString()}
                     </p>
                   )}
@@ -133,7 +133,7 @@ function ListsPage() {
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="text-[#8E8E8E] hover:text-[#222] h-9 gap-1.5"
+                      className="text-ink-muted hover:text-ink h-9 gap-1.5"
                       onClick={(e) => {
                         e.stopPropagation()
                         duplicateList.mutate(list.id)

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -59,7 +59,7 @@ function ListsPage() {
   })
 
   return (
-    <div className="min-h-screen bg-linear-to-b from-slate-900 via-slate-800 to-slate-900 text-white">
+    <div className="min-h-screen bg-[#F4F4F4] text-[#222]">
       <div className="max-w-2xl mx-auto px-4 py-12">
         <div className="flex items-center justify-between mb-8">
           <h1 className="text-2xl font-bold">My Lists</h1>
@@ -77,14 +77,14 @@ function ListsPage() {
 
         {isLoading && (
           <div className="flex justify-center py-12">
-            <Loader2 className="size-6 animate-spin text-slate-400" />
+            <Loader2 className="size-6 animate-spin text-[#8E8E8E]" />
           </div>
         )}
 
         {lists && lists.length === 0 && (
           <div className="text-center py-16">
-            <ShoppingCart className="size-12 mx-auto text-slate-600 mb-4" />
-            <p className="text-slate-400 mb-4">No shopping lists yet</p>
+            <ShoppingCart className="size-12 mx-auto text-[#CFCFCF] mb-4" />
+            <p className="text-[#8E8E8E] mb-4">No shopping lists yet</p>
             <Button onClick={() => createList.mutate()} disabled={createList.isPending}>
               <Plus className="size-4" />
               Create your first list
@@ -98,34 +98,34 @@ function ListsPage() {
               <button
                 key={list.id}
                 onClick={() => navigate({ to: '/list/$listId', params: { listId: list.id } })}
-                className="w-full text-left bg-slate-800 border border-slate-700 rounded-lg p-4 hover:border-slate-500 transition-colors cursor-pointer"
+                className="w-full text-left bg-white border border-[#E8E4DC] rounded-lg p-4 shadow-sm hover:shadow-md hover:border-[#FFB951] transition-all cursor-pointer"
               >
                 <div className="flex items-center justify-between mb-1">
                   <h2 className="font-medium">{list.name}</h2>
-                  <span className="text-sm text-slate-400">
+                  <span className="text-sm text-[#8E8E8E]">
                     {list.checked_count}/{list.item_count} items
                   </span>
                 </div>
 
                 {/* Progress bar */}
                 {list.item_count > 0 && (
-                  <div className="w-full h-1.5 bg-slate-700 rounded-full mb-2">
+                  <div className="w-full h-1.5 bg-[#E8E4DC] rounded-full mb-2">
                     <div
-                      className="h-full bg-emerald-500 rounded-full transition-all"
+                      className="h-full bg-[#FFB951] rounded-full transition-all"
                       style={{ width: `${(list.checked_count / list.item_count) * 100}%` }}
                     />
                   </div>
                 )}
 
                 {list.recipe_titles.length > 0 && (
-                  <p className="text-sm text-slate-400 truncate">
+                  <p className="text-sm text-[#8E8E8E] truncate">
                     {list.recipe_titles.join(', ')}
                   </p>
                 )}
 
                 <div className="flex items-center justify-between mt-2">
                   {list.created_at && (
-                    <p className="text-xs text-slate-500">
+                    <p className="text-xs text-[#ADADAD]">
                       {new Date(list.created_at).toLocaleDateString()}
                     </p>
                   )}
@@ -133,7 +133,7 @@ function ListsPage() {
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="text-slate-500 hover:text-white h-9 gap-1.5"
+                      className="text-[#8E8E8E] hover:text-[#222] h-9 gap-1.5"
                       onClick={(e) => {
                         e.stopPropagation()
                         duplicateList.mutate(list.id)

--- a/client/src/routes/list.$listId.tsx
+++ b/client/src/routes/list.$listId.tsx
@@ -231,17 +231,17 @@ function ListDetailPage() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-linear-to-b from-slate-900 via-slate-800 to-slate-900 text-white flex justify-center pt-24">
-        <Loader2 className="size-6 animate-spin text-slate-400" />
+      <div className="min-h-screen bg-[#F4F4F4] text-[#222] flex justify-center pt-24">
+        <Loader2 className="size-6 animate-spin text-[#8E8E8E]" />
       </div>
     )
   }
 
   if (!list) {
     return (
-      <div className="min-h-screen bg-linear-to-b from-slate-900 via-slate-800 to-slate-900 text-white">
+      <div className="min-h-screen bg-[#F4F4F4] text-[#222]">
         <div className="max-w-2xl mx-auto px-4 py-12">
-          <p className="text-slate-400">List not found</p>
+          <p className="text-[#8E8E8E]">List not found</p>
         </div>
       </div>
     )
@@ -285,13 +285,13 @@ function ListDetailPage() {
   const availableRecipes = allRecipes?.filter((r) => !selectedRecipeIds.has(r.id)) ?? []
 
   return (
-    <div className="min-h-screen bg-linear-to-b from-slate-900 via-slate-800 to-slate-900 text-white">
+    <div className="min-h-screen bg-[#F4F4F4] text-[#222]">
       <div className="flex">
         {/* Main content */}
         <div className="flex-1 min-w-0 max-w-2xl mx-auto px-4 py-6">
           {/* Header */}
           <div className="flex items-center gap-3 mb-2">
-            <Link to="/" className="text-slate-400 hover:text-white transition-colors">
+            <Link to="/" className="text-[#8E8E8E] hover:text-[#222] transition-colors">
               <ArrowLeft className="size-5" />
             </Link>
             <h1 className="text-xl font-bold flex-1">{list.name}</h1>
@@ -299,13 +299,13 @@ function ListDetailPage() {
             <Button
               variant="outline"
               size="sm"
-              className="lg:hidden border-slate-700 text-slate-300 hover:text-white"
+              className="lg:hidden border-[#E8E4DC] text-[#8E8E8E] hover:text-[#222]"
               onClick={() => setShowSidebar(!showSidebar)}
             >
               <UtensilsCrossed className="size-4" />
               Recipes
               {list.recipes.length > 0 && (
-                <span className="ml-1 bg-slate-700 text-xs px-1.5 py-0.5 rounded-full">
+                <span className="ml-1 bg-[#F4F4F4] text-xs px-1.5 py-0.5 rounded-full">
                   {list.recipes.length}
                 </span>
               )}
@@ -316,13 +316,13 @@ function ListDetailPage() {
           {totalItems > 0 && (
             <div className="mb-6 ml-8">
               <div className="flex items-center gap-2 mb-1">
-                <div className="flex-1 h-1.5 bg-slate-700 rounded-full">
+                <div className="flex-1 h-1.5 bg-[#E8E4DC] rounded-full">
                   <div
-                    className="h-full bg-emerald-500 rounded-full transition-all"
+                    className="h-full bg-[#FFB951] rounded-full transition-all"
                     style={{ width: `${(checkedItems / totalItems) * 100}%` }}
                   />
                 </div>
-                <span className="text-xs text-slate-400">
+                <span className="text-xs text-[#8E8E8E]">
                   {checkedItems}/{totalItems}
                 </span>
               </div>
@@ -335,7 +335,7 @@ function ListDetailPage() {
               e.preventDefault()
               handleQuickAdd()
             }}
-            className="sticky top-0 sm:top-14 z-10 bg-slate-900/95 backdrop-blur-sm pb-4 mb-2 -mx-4 px-4 pt-2 sm:static sm:bg-transparent sm:backdrop-blur-none sm:pb-0 sm:mb-6 sm:mx-0 sm:px-0 sm:pt-0"
+            className="sticky top-0 sm:top-14 z-10 bg-[#F4F4F4]/95 backdrop-blur-sm pb-4 mb-2 -mx-4 px-4 pt-2 sm:static sm:bg-transparent sm:backdrop-blur-none sm:pb-0 sm:mb-6 sm:mx-0 sm:px-0 sm:pt-0"
           >
             <div className="flex gap-2">
               <Input
@@ -343,17 +343,17 @@ function ListDetailPage() {
                 value={quickAddValue}
                 onChange={(e) => setQuickAddValue(e.target.value)}
                 placeholder="Add item..."
-                className="flex-1 h-10 bg-slate-800 border-slate-700 text-white placeholder:text-slate-500"
+                className="flex-1 h-10 bg-white border-[#E8E4DC] text-[#222] placeholder:text-[#ADADAD]"
               />
               <Input
                 type="number"
                 value={quickAddAmount}
                 onChange={(e) => setQuickAddAmount(e.target.value)}
                 placeholder="Qty"
-                className="w-16 sm:w-20 h-10 bg-slate-800 border-slate-700 text-white placeholder:text-slate-500"
+                className="w-16 sm:w-20 h-10 bg-white border-[#E8E4DC] text-[#222] placeholder:text-[#ADADAD]"
               />
               <Select value={quickAddUnit} onValueChange={setQuickAddUnit}>
-                <SelectTrigger className="w-24 sm:w-28 h-10 bg-slate-800 border-slate-700 text-white">
+                <SelectTrigger className="w-24 sm:w-28 h-10 bg-white border-[#E8E4DC] text-[#222]">
                   <SelectValue placeholder="Unit" />
                 </SelectTrigger>
                 <SelectContent>
@@ -387,8 +387,8 @@ function ListDetailPage() {
           {/* Empty state */}
           {list.items.length === 0 && (
             <div className="text-center py-12">
-              <p className="text-slate-400 mb-2">No items yet</p>
-              <p className="text-sm text-slate-500">
+              <p className="text-[#8E8E8E] mb-2">No items yet</p>
+              <p className="text-sm text-[#ADADAD]">
                 Add items above or add recipes from the sidebar to get started
               </p>
             </div>
@@ -400,18 +400,18 @@ function ListDetailPage() {
               const isCollapsed = collapsedCategories.has(category)
 
               return (
-                <div key={category} className="bg-slate-800/50 rounded-lg overflow-hidden">
+                <div key={category} className="bg-white rounded-lg border border-[#E8E4DC] shadow-sm overflow-hidden">
                   <button
                     onClick={() => toggleCategory(category)}
-                    className="w-full flex items-center gap-2 px-4 py-3 min-h-[44px] text-sm font-medium text-slate-300 hover:text-white transition-colors cursor-pointer"
+                    className="w-full flex items-center gap-2 px-4 py-3 min-h-[44px] text-sm font-medium text-[#8E8E8E] hover:text-[#222] transition-colors cursor-pointer"
                   >
                     {isCollapsed ? (
-                      <ChevronRight className="size-4 text-slate-500" />
+                      <ChevronRight className="size-4 text-[#ADADAD]" />
                     ) : (
-                      <ChevronDown className="size-4 text-slate-500" />
+                      <ChevronDown className="size-4 text-[#ADADAD]" />
                     )}
                     <span className="flex-1 text-left">{category}</span>
-                    <span className="text-xs text-slate-500">{items.length}</span>
+                    <span className="text-xs text-[#ADADAD]">{items.length}</span>
                   </button>
 
                   {!isCollapsed && (
@@ -446,7 +446,7 @@ function ListDetailPage() {
             <div className="mt-4">
               <button
                 onClick={() => setShowCompleted(!showCompleted)}
-                className="flex items-center gap-2 px-2 py-2 text-sm text-slate-500 hover:text-slate-300 transition-colors cursor-pointer"
+                className="flex items-center gap-2 px-2 py-2 text-sm text-[#8E8E8E] hover:text-[#444] transition-colors cursor-pointer"
               >
                 {showCompleted ? (
                   <ChevronDown className="size-3.5" />
@@ -467,7 +467,7 @@ function ListDetailPage() {
                           updates: { checked: false },
                         })
                       }
-                      className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-slate-800/60 text-xs text-slate-500 line-through hover:bg-slate-700 hover:text-slate-300 transition-colors cursor-pointer"
+                      className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-[#F4F4F4] text-xs text-[#ADADAD] line-through hover:bg-[#E8E4DC] hover:text-[#444] transition-colors cursor-pointer"
                     >
                       <Check className="size-3" />
                       {item.name}
@@ -480,7 +480,7 @@ function ListDetailPage() {
         </div>
 
         {/* Desktop sidebar — fixed to right edge, full height */}
-        <div className="hidden lg:block fixed right-0 top-14 bottom-0 w-80 border-l border-slate-700/50 overflow-y-auto">
+        <div className="hidden lg:block fixed right-0 top-14 bottom-0 w-80 border-l border-[#E8E4DC] overflow-y-auto">
           <RecipeSidebar
             selectedRecipes={selectedRecipes}
             availableRecipes={availableRecipes}
@@ -514,36 +514,36 @@ function RecipeSidebar({
   isRemoving: boolean
 }) {
   return (
-    <div className="bg-slate-800/50 overflow-hidden lg:rounded-none lg:bg-transparent rounded-lg">
-      <div className="px-4 py-3 border-b border-slate-700/50">
+    <div className="bg-white overflow-hidden lg:rounded-none lg:bg-[#FAFAF8] rounded-lg">
+      <div className="px-4 py-3 border-b border-[#E8E4DC]">
         <h2 className="text-sm font-semibold flex items-center gap-2">
-          <UtensilsCrossed className="size-4 text-slate-400" />
+          <UtensilsCrossed className="size-4 text-[#8E8E8E]" />
           Recipes
         </h2>
       </div>
 
       {/* Selected recipes */}
       {selectedRecipes.length > 0 && (
-        <div className="p-3 border-b border-slate-700/50">
-          <h3 className="text-xs font-medium text-slate-500 uppercase tracking-wider mb-2 px-1">
+        <div className="p-3 border-b border-[#E8E4DC]">
+          <h3 className="text-xs font-medium text-[#8E8E8E] uppercase tracking-wider mb-2 px-1">
             On this list
           </h3>
           <div className="space-y-1">
             {selectedRecipes.map((recipe) => (
               <div
                 key={recipe.id}
-                className="flex items-center gap-2 px-2 py-2 rounded-md bg-slate-800"
+                className="flex items-center gap-2 px-2 py-2 rounded-md bg-[#F4F4F4]"
               >
-                <Check className="size-3.5 text-emerald-500 shrink-0" />
+                <Check className="size-3.5 text-[#FFB951] shrink-0" />
                 <div className="flex-1 min-w-0">
                   <Link
                     to="/recipe/$recipeId"
                     params={{ recipeId: recipe.id }}
-                    className="text-sm truncate block hover:text-emerald-400 transition-colors"
+                    className="text-sm truncate block hover:text-[#FFB951] transition-colors"
                   >
                     {recipe.title}
                   </Link>
-                  <p className="text-xs text-slate-500">{recipe.ingredient_count} ingredients</p>
+                  <p className="text-xs text-[#ADADAD]">{recipe.ingredient_count} ingredients</p>
                 </div>
                 <Button
                   variant="ghost"
@@ -562,16 +562,16 @@ function RecipeSidebar({
 
       {/* Available recipes */}
       <div className="p-3">
-        <h3 className="text-xs font-medium text-slate-500 uppercase tracking-wider mb-2 px-1">
+        <h3 className="text-xs font-medium text-[#8E8E8E] uppercase tracking-wider mb-2 px-1">
           {selectedRecipes.length > 0 ? 'Add more' : 'Add recipes'}
         </h3>
         {!allRecipes && (
           <div className="flex justify-center py-4">
-            <Loader2 className="size-5 animate-spin text-slate-400" />
+            <Loader2 className="size-5 animate-spin text-[#8E8E8E]" />
           </div>
         )}
         {allRecipes && availableRecipes.length === 0 && (
-          <p className="text-xs text-slate-500 py-3 text-center">
+          <p className="text-xs text-[#ADADAD] py-3 text-center">
             {allRecipes.length === 0
               ? 'No recipes yet. Create some first!'
               : 'All recipes added'}
@@ -583,13 +583,13 @@ function RecipeSidebar({
               key={recipe.id}
               onClick={() => onAdd(recipe.id)}
               disabled={isAdding}
-              className="w-full flex items-center gap-2 px-2 py-2.5 min-h-[44px] rounded-md hover:bg-slate-800 transition-colors cursor-pointer text-left"
+              className="w-full flex items-center gap-2 px-2 py-2.5 min-h-[44px] rounded-md hover:bg-[#F0EDE6] transition-colors cursor-pointer text-left"
             >
-              <Plus className="size-3.5 text-slate-500 shrink-0" />
+              <Plus className="size-3.5 text-[#CFCFCF] shrink-0" />
               <div className="flex-1 min-w-0">
                 <p className="text-sm truncate">{recipe.title}</p>
                 <div className="flex items-center gap-2">
-                  <span className="text-xs text-slate-500">
+                  <span className="text-xs text-[#ADADAD]">
                     {recipe.ingredient_count} ingredients
                   </span>
                   {recipe.rating && (
@@ -678,13 +678,13 @@ function ItemRow({
 
   if (editing) {
     return (
-      <div className="px-2 py-2 rounded-md bg-slate-800 space-y-2">
+      <div className="px-2 py-2 rounded-md bg-white border border-[#E8E4DC] space-y-2">
         <div className="flex flex-col sm:flex-row gap-2">
           <Input
             value={editName}
             onChange={(e) => setEditName(e.target.value)}
             placeholder="Name"
-            className="flex-1 h-10 bg-slate-700 border-slate-600 text-white text-sm"
+            className="flex-1 h-10 bg-[#F4F4F4] border-[#E0DACE] text-[#222] text-sm"
             autoFocus
             onKeyDown={(e) => {
               if (e.key === 'Enter') handleSave()
@@ -697,14 +697,14 @@ function ItemRow({
               value={editAmount}
               onChange={(e) => setEditAmount(e.target.value)}
               placeholder="Qty"
-              className="w-20 h-10 bg-slate-700 border-slate-600 text-white text-sm"
+              className="w-20 h-10 bg-[#F4F4F4] border-[#E0DACE] text-[#222] text-sm"
               onKeyDown={(e) => {
                 if (e.key === 'Enter') handleSave()
                 if (e.key === 'Escape') handleCancel()
               }}
             />
             <Select value={editUnit} onValueChange={setEditUnit}>
-              <SelectTrigger className="w-28 h-10 bg-slate-700 border-slate-600 text-white text-sm">
+              <SelectTrigger className="w-28 h-10 bg-[#F4F4F4] border-[#E0DACE] text-[#222] text-sm">
                 <SelectValue placeholder="Unit" />
               </SelectTrigger>
               <SelectContent>
@@ -718,7 +718,7 @@ function ItemRow({
         </div>
         <div className="flex items-center gap-2">
           <Select value={editCategory} onValueChange={setEditCategory}>
-            <SelectTrigger className="w-40 h-10 bg-slate-700 border-slate-600 text-white text-sm">
+            <SelectTrigger className="w-40 h-10 bg-[#F4F4F4] border-[#E0DACE] text-[#222] text-sm">
               <SelectValue placeholder="Category" />
             </SelectTrigger>
             <SelectContent>
@@ -728,7 +728,7 @@ function ItemRow({
             </SelectContent>
           </Select>
           <div className="flex-1" />
-          <Button variant="ghost" size="sm" onClick={handleCancel} className="h-9 px-3 text-slate-400 hover:text-white">
+          <Button variant="ghost" size="sm" onClick={handleCancel} className="h-9 px-3 text-[#8E8E8E] hover:text-[#222]">
             Cancel
           </Button>
           <Button size="sm" onClick={handleSave} className="h-9 px-3">
@@ -751,25 +751,25 @@ function ItemRow({
         onTouchMove={handleTouchMove}
         onTouchEnd={handleTouchEnd}
         style={{ transform: `translateX(-${swipeOffset}px)` }}
-        className={`relative flex items-center gap-3 px-2 py-2.5 rounded-md group bg-slate-900 transition-opacity ${
+        className={`relative flex items-center gap-3 px-2 py-2.5 rounded-md group bg-white transition-opacity ${
           !swiping ? 'transition-transform duration-200' : ''
         } ${item.checked ? 'opacity-50' : ''}`}
       >
         <Checkbox
           checked={item.checked}
           onCheckedChange={onToggleCheck}
-          className="shrink-0 size-5 border-slate-600 data-[state=checked]:bg-emerald-600 data-[state=checked]:border-emerald-600"
+          className="shrink-0 size-5 border-[#CFCFCF] data-[state=checked]:bg-[#FFB951] data-[state=checked]:border-[#FFB951] [&>[data-state=checked]>svg]:text-[#222]"
         />
 
-        <div className={`flex-1 min-w-0 ${item.checked ? 'line-through text-slate-400' : ''}`}>
+        <div className={`flex-1 min-w-0 ${item.checked ? 'line-through text-[#8E8E8E]' : ''}`}>
           <span className="text-sm">{item.name}</span>
           {(item.amount != null || item.unit) && (
-            <span className="text-xs text-slate-400 ml-2">
+            <span className="text-xs text-[#ADADAD] ml-2">
               {item.amount != null ? item.amount : ''}{item.unit ? ` ${item.unit}` : ''}
             </span>
           )}
           {item.sources.filter((s) => s.recipe_id).length > 1 && (
-            <span className="ml-2 text-[10px] text-slate-500 bg-slate-800 px-1.5 py-0.5 rounded-full">
+            <span className="ml-2 text-[10px] text-[#8E8E8E] bg-[#F4F4F4] px-1.5 py-0.5 rounded-full">
               {item.sources.filter((s) => s.recipe_id).length} recipes
             </span>
           )}
@@ -779,7 +779,7 @@ function ItemRow({
           variant="ghost"
           size="icon-xs"
           onClick={() => setEditing(true)}
-          className="shrink-0 size-8 text-slate-600 hover:text-slate-300 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
+          className="shrink-0 size-8 text-[#CFCFCF] hover:text-[#444] sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
         >
           <Pencil className="size-3.5" />
         </Button>
@@ -787,7 +787,7 @@ function ItemRow({
           variant="ghost"
           size="icon-xs"
           onClick={onDelete}
-          className="shrink-0 size-8 text-slate-600 hover:text-red-400 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
+          className="shrink-0 size-8 text-[#CFCFCF] hover:text-red-400 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
         >
           <Trash2 className="size-3.5" />
         </Button>

--- a/client/src/routes/list.$listId.tsx
+++ b/client/src/routes/list.$listId.tsx
@@ -231,17 +231,17 @@ function ListDetailPage() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-[#F4F4F4] text-[#222] flex justify-center pt-24">
-        <Loader2 className="size-6 animate-spin text-[#8E8E8E]" />
+      <div className="min-h-screen bg-cream text-ink flex justify-center pt-24">
+        <Loader2 className="size-6 animate-spin text-ink-muted" />
       </div>
     )
   }
 
   if (!list) {
     return (
-      <div className="min-h-screen bg-[#F4F4F4] text-[#222]">
+      <div className="min-h-screen bg-cream text-ink">
         <div className="max-w-2xl mx-auto px-4 py-12">
-          <p className="text-[#8E8E8E]">List not found</p>
+          <p className="text-ink-muted">List not found</p>
         </div>
       </div>
     )
@@ -285,13 +285,13 @@ function ListDetailPage() {
   const availableRecipes = allRecipes?.filter((r) => !selectedRecipeIds.has(r.id)) ?? []
 
   return (
-    <div className="min-h-screen bg-[#F4F4F4] text-[#222]">
+    <div className="min-h-screen bg-cream text-ink">
       <div className="flex">
         {/* Main content */}
         <div className="flex-1 min-w-0 max-w-2xl mx-auto px-4 py-6">
           {/* Header */}
           <div className="flex items-center gap-3 mb-2">
-            <Link to="/" className="text-[#8E8E8E] hover:text-[#222] transition-colors">
+            <Link to="/" className="text-ink-muted hover:text-ink transition-colors">
               <ArrowLeft className="size-5" />
             </Link>
             <h1 className="text-xl font-bold flex-1">{list.name}</h1>
@@ -299,13 +299,13 @@ function ListDetailPage() {
             <Button
               variant="outline"
               size="sm"
-              className="lg:hidden border-[#E8E4DC] text-[#8E8E8E] hover:text-[#222]"
+              className="lg:hidden border-line text-ink-muted hover:text-ink"
               onClick={() => setShowSidebar(!showSidebar)}
             >
               <UtensilsCrossed className="size-4" />
               Recipes
               {list.recipes.length > 0 && (
-                <span className="ml-1 bg-[#F4F4F4] text-xs px-1.5 py-0.5 rounded-full">
+                <span className="ml-1 bg-cream text-xs px-1.5 py-0.5 rounded-full">
                   {list.recipes.length}
                 </span>
               )}
@@ -316,13 +316,13 @@ function ListDetailPage() {
           {totalItems > 0 && (
             <div className="mb-6 ml-8">
               <div className="flex items-center gap-2 mb-1">
-                <div className="flex-1 h-1.5 bg-[#E8E4DC] rounded-full">
+                <div className="flex-1 h-1.5 bg-line rounded-full">
                   <div
-                    className="h-full bg-[#FFB951] rounded-full transition-all"
+                    className="h-full bg-primary rounded-full transition-all"
                     style={{ width: `${(checkedItems / totalItems) * 100}%` }}
                   />
                 </div>
-                <span className="text-xs text-[#8E8E8E]">
+                <span className="text-xs text-ink-muted">
                   {checkedItems}/{totalItems}
                 </span>
               </div>
@@ -335,7 +335,7 @@ function ListDetailPage() {
               e.preventDefault()
               handleQuickAdd()
             }}
-            className="sticky top-0 sm:top-14 z-10 bg-[#F4F4F4]/95 backdrop-blur-sm pb-4 mb-2 -mx-4 px-4 pt-2 sm:static sm:bg-transparent sm:backdrop-blur-none sm:pb-0 sm:mb-6 sm:mx-0 sm:px-0 sm:pt-0"
+            className="sticky top-0 sm:top-14 z-10 bg-cream/95 backdrop-blur-sm pb-4 mb-2 -mx-4 px-4 pt-2 sm:static sm:bg-transparent sm:backdrop-blur-none sm:pb-0 sm:mb-6 sm:mx-0 sm:px-0 sm:pt-0"
           >
             <div className="flex gap-2">
               <Input
@@ -343,17 +343,17 @@ function ListDetailPage() {
                 value={quickAddValue}
                 onChange={(e) => setQuickAddValue(e.target.value)}
                 placeholder="Add item..."
-                className="flex-1 h-10 bg-white border-[#E8E4DC] text-[#222] placeholder:text-[#ADADAD]"
+                className="flex-1 h-10 bg-white border-line text-ink placeholder:text-ink-faint"
               />
               <Input
                 type="number"
                 value={quickAddAmount}
                 onChange={(e) => setQuickAddAmount(e.target.value)}
                 placeholder="Qty"
-                className="w-16 sm:w-20 h-10 bg-white border-[#E8E4DC] text-[#222] placeholder:text-[#ADADAD]"
+                className="w-16 sm:w-20 h-10 bg-white border-line text-ink placeholder:text-ink-faint"
               />
               <Select value={quickAddUnit} onValueChange={setQuickAddUnit}>
-                <SelectTrigger className="w-24 sm:w-28 h-10 bg-white border-[#E8E4DC] text-[#222]">
+                <SelectTrigger className="w-24 sm:w-28 h-10 bg-white border-line text-ink">
                   <SelectValue placeholder="Unit" />
                 </SelectTrigger>
                 <SelectContent>
@@ -387,8 +387,8 @@ function ListDetailPage() {
           {/* Empty state */}
           {list.items.length === 0 && (
             <div className="text-center py-12">
-              <p className="text-[#8E8E8E] mb-2">No items yet</p>
-              <p className="text-sm text-[#ADADAD]">
+              <p className="text-ink-muted mb-2">No items yet</p>
+              <p className="text-sm text-ink-faint">
                 Add items above or add recipes from the sidebar to get started
               </p>
             </div>
@@ -400,18 +400,18 @@ function ListDetailPage() {
               const isCollapsed = collapsedCategories.has(category)
 
               return (
-                <div key={category} className="bg-white rounded-lg border border-[#E8E4DC] shadow-sm overflow-hidden">
+                <div key={category} className="bg-white rounded-lg border border-line shadow-sm overflow-hidden">
                   <button
                     onClick={() => toggleCategory(category)}
-                    className="w-full flex items-center gap-2 px-4 py-3 min-h-[44px] text-sm font-medium text-[#8E8E8E] hover:text-[#222] transition-colors cursor-pointer"
+                    className="w-full flex items-center gap-2 px-4 py-3 min-h-[44px] text-sm font-medium text-ink-muted hover:text-ink transition-colors cursor-pointer"
                   >
                     {isCollapsed ? (
-                      <ChevronRight className="size-4 text-[#ADADAD]" />
+                      <ChevronRight className="size-4 text-ink-faint" />
                     ) : (
-                      <ChevronDown className="size-4 text-[#ADADAD]" />
+                      <ChevronDown className="size-4 text-ink-faint" />
                     )}
                     <span className="flex-1 text-left">{category}</span>
-                    <span className="text-xs text-[#ADADAD]">{items.length}</span>
+                    <span className="text-xs text-ink-faint">{items.length}</span>
                   </button>
 
                   {!isCollapsed && (
@@ -446,7 +446,7 @@ function ListDetailPage() {
             <div className="mt-4">
               <button
                 onClick={() => setShowCompleted(!showCompleted)}
-                className="flex items-center gap-2 px-2 py-2 text-sm text-[#8E8E8E] hover:text-[#444] transition-colors cursor-pointer"
+                className="flex items-center gap-2 px-2 py-2 text-sm text-ink-muted hover:text-ink-soft transition-colors cursor-pointer"
               >
                 {showCompleted ? (
                   <ChevronDown className="size-3.5" />
@@ -467,7 +467,7 @@ function ListDetailPage() {
                           updates: { checked: false },
                         })
                       }
-                      className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-[#F4F4F4] text-xs text-[#ADADAD] line-through hover:bg-[#E8E4DC] hover:text-[#444] transition-colors cursor-pointer"
+                      className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-cream text-xs text-ink-faint line-through hover:bg-line hover:text-ink-soft transition-colors cursor-pointer"
                     >
                       <Check className="size-3" />
                       {item.name}
@@ -480,7 +480,7 @@ function ListDetailPage() {
         </div>
 
         {/* Desktop sidebar — fixed to right edge, full height */}
-        <div className="hidden lg:block fixed right-0 top-14 bottom-0 w-80 border-l border-[#E8E4DC] overflow-y-auto">
+        <div className="hidden lg:block fixed right-0 top-14 bottom-0 w-80 border-l border-line overflow-y-auto">
           <RecipeSidebar
             selectedRecipes={selectedRecipes}
             availableRecipes={availableRecipes}
@@ -514,36 +514,36 @@ function RecipeSidebar({
   isRemoving: boolean
 }) {
   return (
-    <div className="bg-white overflow-hidden lg:rounded-none lg:bg-[#FAFAF8] rounded-lg">
-      <div className="px-4 py-3 border-b border-[#E8E4DC]">
+    <div className="bg-white overflow-hidden lg:rounded-none lg:bg-linen rounded-lg">
+      <div className="px-4 py-3 border-b border-line">
         <h2 className="text-sm font-semibold flex items-center gap-2">
-          <UtensilsCrossed className="size-4 text-[#8E8E8E]" />
+          <UtensilsCrossed className="size-4 text-ink-muted" />
           Recipes
         </h2>
       </div>
 
       {/* Selected recipes */}
       {selectedRecipes.length > 0 && (
-        <div className="p-3 border-b border-[#E8E4DC]">
-          <h3 className="text-xs font-medium text-[#8E8E8E] uppercase tracking-wider mb-2 px-1">
+        <div className="p-3 border-b border-line">
+          <h3 className="text-xs font-medium text-ink-muted uppercase tracking-wider mb-2 px-1">
             On this list
           </h3>
           <div className="space-y-1">
             {selectedRecipes.map((recipe) => (
               <div
                 key={recipe.id}
-                className="flex items-center gap-2 px-2 py-2 rounded-md bg-[#F4F4F4]"
+                className="flex items-center gap-2 px-2 py-2 rounded-md bg-cream"
               >
-                <Check className="size-3.5 text-[#FFB951] shrink-0" />
+                <Check className="size-3.5 text-primary shrink-0" />
                 <div className="flex-1 min-w-0">
                   <Link
                     to="/recipe/$recipeId"
                     params={{ recipeId: recipe.id }}
-                    className="text-sm truncate block hover:text-[#FFB951] transition-colors"
+                    className="text-sm truncate block hover:text-primary transition-colors"
                   >
                     {recipe.title}
                   </Link>
-                  <p className="text-xs text-[#ADADAD]">{recipe.ingredient_count} ingredients</p>
+                  <p className="text-xs text-ink-faint">{recipe.ingredient_count} ingredients</p>
                 </div>
                 <Button
                   variant="ghost"
@@ -562,16 +562,16 @@ function RecipeSidebar({
 
       {/* Available recipes */}
       <div className="p-3">
-        <h3 className="text-xs font-medium text-[#8E8E8E] uppercase tracking-wider mb-2 px-1">
+        <h3 className="text-xs font-medium text-ink-muted uppercase tracking-wider mb-2 px-1">
           {selectedRecipes.length > 0 ? 'Add more' : 'Add recipes'}
         </h3>
         {!allRecipes && (
           <div className="flex justify-center py-4">
-            <Loader2 className="size-5 animate-spin text-[#8E8E8E]" />
+            <Loader2 className="size-5 animate-spin text-ink-muted" />
           </div>
         )}
         {allRecipes && availableRecipes.length === 0 && (
-          <p className="text-xs text-[#ADADAD] py-3 text-center">
+          <p className="text-xs text-ink-faint py-3 text-center">
             {allRecipes.length === 0
               ? 'No recipes yet. Create some first!'
               : 'All recipes added'}
@@ -583,13 +583,13 @@ function RecipeSidebar({
               key={recipe.id}
               onClick={() => onAdd(recipe.id)}
               disabled={isAdding}
-              className="w-full flex items-center gap-2 px-2 py-2.5 min-h-[44px] rounded-md hover:bg-[#F0EDE6] transition-colors cursor-pointer text-left"
+              className="w-full flex items-center gap-2 px-2 py-2.5 min-h-[44px] rounded-md hover:bg-sand transition-colors cursor-pointer text-left"
             >
-              <Plus className="size-3.5 text-[#CFCFCF] shrink-0" />
+              <Plus className="size-3.5 text-ink-subtle shrink-0" />
               <div className="flex-1 min-w-0">
                 <p className="text-sm truncate">{recipe.title}</p>
                 <div className="flex items-center gap-2">
-                  <span className="text-xs text-[#ADADAD]">
+                  <span className="text-xs text-ink-faint">
                     {recipe.ingredient_count} ingredients
                   </span>
                   {recipe.rating && (
@@ -678,13 +678,13 @@ function ItemRow({
 
   if (editing) {
     return (
-      <div className="px-2 py-2 rounded-md bg-white border border-[#E8E4DC] space-y-2">
+      <div className="px-2 py-2 rounded-md bg-white border border-line space-y-2">
         <div className="flex flex-col sm:flex-row gap-2">
           <Input
             value={editName}
             onChange={(e) => setEditName(e.target.value)}
             placeholder="Name"
-            className="flex-1 h-10 bg-[#F4F4F4] border-[#E0DACE] text-[#222] text-sm"
+            className="flex-1 h-10 bg-cream border-line-strong text-ink text-sm"
             autoFocus
             onKeyDown={(e) => {
               if (e.key === 'Enter') handleSave()
@@ -697,14 +697,14 @@ function ItemRow({
               value={editAmount}
               onChange={(e) => setEditAmount(e.target.value)}
               placeholder="Qty"
-              className="w-20 h-10 bg-[#F4F4F4] border-[#E0DACE] text-[#222] text-sm"
+              className="w-20 h-10 bg-cream border-line-strong text-ink text-sm"
               onKeyDown={(e) => {
                 if (e.key === 'Enter') handleSave()
                 if (e.key === 'Escape') handleCancel()
               }}
             />
             <Select value={editUnit} onValueChange={setEditUnit}>
-              <SelectTrigger className="w-28 h-10 bg-[#F4F4F4] border-[#E0DACE] text-[#222] text-sm">
+              <SelectTrigger className="w-28 h-10 bg-cream border-line-strong text-ink text-sm">
                 <SelectValue placeholder="Unit" />
               </SelectTrigger>
               <SelectContent>
@@ -718,7 +718,7 @@ function ItemRow({
         </div>
         <div className="flex items-center gap-2">
           <Select value={editCategory} onValueChange={setEditCategory}>
-            <SelectTrigger className="w-40 h-10 bg-[#F4F4F4] border-[#E0DACE] text-[#222] text-sm">
+            <SelectTrigger className="w-40 h-10 bg-cream border-line-strong text-ink text-sm">
               <SelectValue placeholder="Category" />
             </SelectTrigger>
             <SelectContent>
@@ -728,7 +728,7 @@ function ItemRow({
             </SelectContent>
           </Select>
           <div className="flex-1" />
-          <Button variant="ghost" size="sm" onClick={handleCancel} className="h-9 px-3 text-[#8E8E8E] hover:text-[#222]">
+          <Button variant="ghost" size="sm" onClick={handleCancel} className="h-9 px-3 text-ink-muted hover:text-ink">
             Cancel
           </Button>
           <Button size="sm" onClick={handleSave} className="h-9 px-3">
@@ -758,18 +758,18 @@ function ItemRow({
         <Checkbox
           checked={item.checked}
           onCheckedChange={onToggleCheck}
-          className="shrink-0 size-5 border-[#CFCFCF] data-[state=checked]:bg-[#FFB951] data-[state=checked]:border-[#FFB951] [&>[data-state=checked]>svg]:text-[#222]"
+          className="shrink-0 size-5 border-ink-subtle data-[state=checked]:bg-primary data-[state=checked]:border-primary [&>[data-state=checked]>svg]:text-ink"
         />
 
-        <div className={`flex-1 min-w-0 ${item.checked ? 'line-through text-[#8E8E8E]' : ''}`}>
+        <div className={`flex-1 min-w-0 ${item.checked ? 'line-through text-ink-muted' : ''}`}>
           <span className="text-sm">{item.name}</span>
           {(item.amount != null || item.unit) && (
-            <span className="text-xs text-[#ADADAD] ml-2">
+            <span className="text-xs text-ink-faint ml-2">
               {item.amount != null ? item.amount : ''}{item.unit ? ` ${item.unit}` : ''}
             </span>
           )}
           {item.sources.filter((s) => s.recipe_id).length > 1 && (
-            <span className="ml-2 text-[10px] text-[#8E8E8E] bg-[#F4F4F4] px-1.5 py-0.5 rounded-full">
+            <span className="ml-2 text-[10px] text-ink-muted bg-cream px-1.5 py-0.5 rounded-full">
               {item.sources.filter((s) => s.recipe_id).length} recipes
             </span>
           )}
@@ -779,7 +779,7 @@ function ItemRow({
           variant="ghost"
           size="icon-xs"
           onClick={() => setEditing(true)}
-          className="shrink-0 size-8 text-[#CFCFCF] hover:text-[#444] sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
+          className="shrink-0 size-8 text-ink-subtle hover:text-ink-soft sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
         >
           <Pencil className="size-3.5" />
         </Button>
@@ -787,7 +787,7 @@ function ItemRow({
           variant="ghost"
           size="icon-xs"
           onClick={onDelete}
-          className="shrink-0 size-8 text-[#CFCFCF] hover:text-red-400 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
+          className="shrink-0 size-8 text-ink-subtle hover:text-red-400 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
         >
           <Trash2 className="size-3.5" />
         </Button>

--- a/client/src/routes/recipe.$recipeId.tsx
+++ b/client/src/routes/recipe.$recipeId.tsx
@@ -170,19 +170,19 @@ function RecipeDetailPage() {
     : []
 
   return (
-    <div className="min-h-screen bg-[#F4F4F4] text-[#222]">
+    <div className="min-h-screen bg-cream text-ink">
       <div className="max-w-2xl mx-auto px-4 py-12">
         <div className="flex items-center justify-between mb-6">
           <Link
             to="/recipes"
-            className="inline-flex items-center gap-1.5 text-sm text-[#8E8E8E] hover:text-[#222] transition-colors"
+            className="inline-flex items-center gap-1.5 text-sm text-ink-muted hover:text-ink transition-colors"
           >
             <ArrowLeft className="size-4" />
             Back to recipes
           </Link>
           {recipe && !editing && (
             <div className="flex items-center gap-2">
-              <Button variant="outline" size="sm" onClick={startEditing} className="gap-1.5 border-[#E8E4DC] text-[#8E8E8E]">
+              <Button variant="outline" size="sm" onClick={startEditing} className="gap-1.5 border-line text-ink-muted">
                 <Pencil className="size-3.5" />
                 Edit
               </Button>
@@ -204,7 +204,7 @@ function RecipeDetailPage() {
           )}
           {editing && (
             <div className="flex items-center gap-2">
-              <Button variant="ghost" size="sm" onClick={cancelEditing} className="text-[#8E8E8E]">
+              <Button variant="ghost" size="sm" onClick={cancelEditing} className="text-ink-muted">
                 Cancel
               </Button>
               <Button size="sm" onClick={() => saveRecipe.mutate()} disabled={saveRecipe.isPending} className="gap-1.5">
@@ -216,34 +216,34 @@ function RecipeDetailPage() {
         </div>
 
         {isLoading && (
-          <div className="flex items-center gap-2 text-[#8E8E8E]">
+          <div className="flex items-center gap-2 text-ink-muted">
             <Loader2 className="size-5 animate-spin" />
             Loading recipe...
           </div>
         )}
 
         {recipe && (
-          <div className="bg-white border border-[#E8E4DC] rounded-xl p-6 space-y-5 shadow-sm">
+          <div className="bg-white border border-line rounded-xl p-6 space-y-5 shadow-sm">
             {/* Title */}
             {editing ? (
               <Input
                 value={editTitle}
                 onChange={(e) => setEditTitle(e.target.value)}
-                className="text-xl font-semibold bg-[#F4F4F4] border-[#E0DACE] text-[#222] h-auto py-2"
+                className="text-xl font-semibold bg-cream border-line-strong text-ink h-auto py-2"
               />
             ) : (
-              <h2 className="text-xl font-semibold text-[#222]">{recipe.title}</h2>
+              <h2 className="text-xl font-semibold text-ink">{recipe.title}</h2>
             )}
 
             {/* Date + Rating */}
             <div className="flex items-center justify-between">
-              <div className="text-sm text-[#8E8E8E]">
+              <div className="text-sm text-ink-muted">
                 {recipe.created_at
                   ? new Date(recipe.created_at).toLocaleDateString()
                   : ''}
               </div>
               <div className="flex items-center gap-3">
-                <span className="text-sm text-[#8E8E8E]">Rate</span>
+                <span className="text-sm text-ink-muted">Rate</span>
                 <StarRating
                   value={recipe.rating}
                   onChange={(rating) => ratingMutation.mutate(rating)}
@@ -253,7 +253,7 @@ function RecipeDetailPage() {
 
               {/* Ingredients */}
               <div>
-                <h3 className="text-xs font-semibold text-[#8E8E8E] uppercase tracking-wider mb-3">
+                <h3 className="text-xs font-semibold text-ink-muted uppercase tracking-wider mb-3">
                   Ingredients
                 </h3>
                 {editing ? (
@@ -268,7 +268,7 @@ function RecipeDetailPage() {
                             setEditIngredients(updated)
                           }}
                           placeholder="Name"
-                          className="flex-1 h-9 bg-[#F4F4F4] border-[#E0DACE] text-[#222] text-sm"
+                          className="flex-1 h-9 bg-cream border-line-strong text-ink text-sm"
                         />
                         <Input
                           type="number"
@@ -279,7 +279,7 @@ function RecipeDetailPage() {
                             setEditIngredients(updated)
                           }}
                           placeholder="Qty"
-                          className="w-20 h-9 bg-[#F4F4F4] border-[#E0DACE] text-[#222] text-sm"
+                          className="w-20 h-9 bg-cream border-line-strong text-ink text-sm"
                         />
                         <Select
                           value={ing.unit}
@@ -289,7 +289,7 @@ function RecipeDetailPage() {
                             setEditIngredients(updated)
                           }}
                         >
-                          <SelectTrigger className="w-28 h-9 bg-[#F4F4F4] border-[#E0DACE] text-[#222] text-sm">
+                          <SelectTrigger className="w-28 h-9 bg-cream border-line-strong text-ink text-sm">
                             <SelectValue placeholder="Unit" />
                           </SelectTrigger>
                           <SelectContent>
@@ -306,7 +306,7 @@ function RecipeDetailPage() {
                             setEditIngredients(updated)
                           }}
                         >
-                          <SelectTrigger className="w-36 h-9 bg-[#F4F4F4] border-[#E0DACE] text-[#222] text-sm">
+                          <SelectTrigger className="w-36 h-9 bg-cream border-line-strong text-ink text-sm">
                             <SelectValue placeholder="Category" />
                           </SelectTrigger>
                           <SelectContent>
@@ -334,7 +334,7 @@ function RecipeDetailPage() {
                           { name: '', unit: '', amount: 0, category: 'Other', excluded_from_list: false },
                         ])
                       }
-                      className="gap-1.5 text-[#8E8E8E] hover:text-[#222]"
+                      className="gap-1.5 text-ink-muted hover:text-ink"
                     >
                       <Plus className="size-3.5" />
                       Add ingredient
@@ -346,11 +346,11 @@ function RecipeDetailPage() {
                       <li
                         key={i}
                         className={`text-sm flex items-center gap-2 ${
-                          ing.excluded_from_list ? 'opacity-40' : 'text-[#444]'
+                          ing.excluded_from_list ? 'opacity-40' : 'text-ink-soft'
                         }`}
                       >
                         <span className="flex-1">{ing.name}</span>
-                        <span className="text-[#222] font-medium shrink-0">
+                        <span className="text-ink font-medium shrink-0">
                           {ing.amount} {ing.unit}
                         </span>
                         <button
@@ -360,7 +360,7 @@ function RecipeDetailPage() {
                               excluded: !ing.excluded_from_list,
                             })
                           }
-                          className="shrink-0 text-[#ADADAD] hover:text-[#8E8E8E] transition-colors cursor-pointer"
+                          className="shrink-0 text-ink-faint hover:text-ink-muted transition-colors cursor-pointer"
                           title={ing.excluded_from_list ? 'Include in shopping list' : 'Exclude from shopping list'}
                         >
                           {ing.excluded_from_list ? (
@@ -377,14 +377,14 @@ function RecipeDetailPage() {
 
               {/* Instructions */}
               <div>
-                <h3 className="text-xs font-semibold text-[#8E8E8E] uppercase tracking-wider mb-3">
+                <h3 className="text-xs font-semibold text-ink-muted uppercase tracking-wider mb-3">
                   Instructions
                 </h3>
                 {editing ? (
                   <div className="space-y-2">
                     {editInstructions.map((step, i) => (
                       <div key={i} className="flex items-start gap-2">
-                        <span className="text-[#ADADAD] font-mono text-sm pt-2.5 shrink-0">{i + 1}.</span>
+                        <span className="text-ink-faint font-mono text-sm pt-2.5 shrink-0">{i + 1}.</span>
                         <textarea
                           value={step}
                           onChange={(e) => {
@@ -393,7 +393,7 @@ function RecipeDetailPage() {
                             setEditInstructions(updated)
                           }}
                           rows={2}
-                          className="flex-1 bg-[#F4F4F4] border border-[#E0DACE] rounded-md px-3 py-2 text-sm text-[#222] resize-none focus:outline-none focus:ring-2 focus:ring-[#FFB951]"
+                          className="flex-1 bg-cream border border-line-strong rounded-md px-3 py-2 text-sm text-ink resize-none focus:outline-none focus:ring-2 focus:ring-primary"
                         />
                         <div className="flex flex-col gap-0.5 shrink-0">
                           <Button
@@ -406,7 +406,7 @@ function RecipeDetailPage() {
                               setEditInstructions(updated)
                             }}
                             disabled={i === 0}
-                            className="size-7 text-[#ADADAD] hover:text-[#222]"
+                            className="size-7 text-ink-faint hover:text-ink"
                           >
                             <ArrowUp className="size-3.5" />
                           </Button>
@@ -420,7 +420,7 @@ function RecipeDetailPage() {
                               setEditInstructions(updated)
                             }}
                             disabled={i === editInstructions.length - 1}
-                            className="size-7 text-[#ADADAD] hover:text-[#222]"
+                            className="size-7 text-ink-faint hover:text-ink"
                           >
                             <ArrowDown className="size-3.5" />
                           </Button>
@@ -439,7 +439,7 @@ function RecipeDetailPage() {
                       variant="ghost"
                       size="sm"
                       onClick={() => setEditInstructions([...editInstructions, ''])}
-                      className="gap-1.5 text-[#8E8E8E] hover:text-[#222]"
+                      className="gap-1.5 text-ink-muted hover:text-ink"
                     >
                       <Plus className="size-3.5" />
                       Add step
@@ -448,8 +448,8 @@ function RecipeDetailPage() {
                 ) : (
                   <ol className="space-y-2.5">
                     {recipe.instructions.map((step, i) => (
-                      <li key={i} className="text-sm text-[#444] flex gap-3">
-                        <span className="text-[#ADADAD] font-mono shrink-0 pt-px">{i + 1}.</span>
+                      <li key={i} className="text-sm text-ink-soft flex gap-3">
+                        <span className="text-ink-faint font-mono shrink-0 pt-px">{i + 1}.</span>
                         <span>{highlightAmounts(step)}</span>
                       </li>
                     ))}

--- a/client/src/routes/recipe.$recipeId.tsx
+++ b/client/src/routes/recipe.$recipeId.tsx
@@ -170,19 +170,19 @@ function RecipeDetailPage() {
     : []
 
   return (
-    <div className="min-h-screen bg-linear-to-b from-slate-900 via-slate-800 to-slate-900 text-white">
+    <div className="min-h-screen bg-[#F4F4F4] text-[#222]">
       <div className="max-w-2xl mx-auto px-4 py-12">
         <div className="flex items-center justify-between mb-6">
           <Link
             to="/recipes"
-            className="inline-flex items-center gap-1.5 text-sm text-slate-400 hover:text-white transition-colors"
+            className="inline-flex items-center gap-1.5 text-sm text-[#8E8E8E] hover:text-[#222] transition-colors"
           >
             <ArrowLeft className="size-4" />
             Back to recipes
           </Link>
           {recipe && !editing && (
             <div className="flex items-center gap-2">
-              <Button variant="outline" size="sm" onClick={startEditing} className="gap-1.5 border-slate-700 text-slate-300">
+              <Button variant="outline" size="sm" onClick={startEditing} className="gap-1.5 border-[#E8E4DC] text-[#8E8E8E]">
                 <Pencil className="size-3.5" />
                 Edit
               </Button>
@@ -204,7 +204,7 @@ function RecipeDetailPage() {
           )}
           {editing && (
             <div className="flex items-center gap-2">
-              <Button variant="ghost" size="sm" onClick={cancelEditing} className="text-slate-400">
+              <Button variant="ghost" size="sm" onClick={cancelEditing} className="text-[#8E8E8E]">
                 Cancel
               </Button>
               <Button size="sm" onClick={() => saveRecipe.mutate()} disabled={saveRecipe.isPending} className="gap-1.5">
@@ -216,34 +216,34 @@ function RecipeDetailPage() {
         </div>
 
         {isLoading && (
-          <div className="flex items-center gap-2 text-slate-400">
+          <div className="flex items-center gap-2 text-[#8E8E8E]">
             <Loader2 className="size-5 animate-spin" />
             Loading recipe...
           </div>
         )}
 
         {recipe && (
-          <div className="bg-slate-800 border border-slate-700 rounded-xl p-6 space-y-5">
+          <div className="bg-white border border-[#E8E4DC] rounded-xl p-6 space-y-5 shadow-sm">
             {/* Title */}
             {editing ? (
               <Input
                 value={editTitle}
                 onChange={(e) => setEditTitle(e.target.value)}
-                className="text-xl font-semibold bg-slate-700 border-slate-600 text-white h-auto py-2"
+                className="text-xl font-semibold bg-[#F4F4F4] border-[#E0DACE] text-[#222] h-auto py-2"
               />
             ) : (
-              <h2 className="text-xl font-semibold text-white">{recipe.title}</h2>
+              <h2 className="text-xl font-semibold text-[#222]">{recipe.title}</h2>
             )}
 
             {/* Date + Rating */}
             <div className="flex items-center justify-between">
-              <div className="text-sm text-slate-400">
+              <div className="text-sm text-[#8E8E8E]">
                 {recipe.created_at
                   ? new Date(recipe.created_at).toLocaleDateString()
                   : ''}
               </div>
               <div className="flex items-center gap-3">
-                <span className="text-sm text-slate-400">Rate</span>
+                <span className="text-sm text-[#8E8E8E]">Rate</span>
                 <StarRating
                   value={recipe.rating}
                   onChange={(rating) => ratingMutation.mutate(rating)}
@@ -253,7 +253,7 @@ function RecipeDetailPage() {
 
               {/* Ingredients */}
               <div>
-                <h3 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-3">
+                <h3 className="text-xs font-semibold text-[#8E8E8E] uppercase tracking-wider mb-3">
                   Ingredients
                 </h3>
                 {editing ? (
@@ -268,7 +268,7 @@ function RecipeDetailPage() {
                             setEditIngredients(updated)
                           }}
                           placeholder="Name"
-                          className="flex-1 h-9 bg-slate-700 border-slate-600 text-white text-sm"
+                          className="flex-1 h-9 bg-[#F4F4F4] border-[#E0DACE] text-[#222] text-sm"
                         />
                         <Input
                           type="number"
@@ -279,7 +279,7 @@ function RecipeDetailPage() {
                             setEditIngredients(updated)
                           }}
                           placeholder="Qty"
-                          className="w-20 h-9 bg-slate-700 border-slate-600 text-white text-sm"
+                          className="w-20 h-9 bg-[#F4F4F4] border-[#E0DACE] text-[#222] text-sm"
                         />
                         <Select
                           value={ing.unit}
@@ -289,7 +289,7 @@ function RecipeDetailPage() {
                             setEditIngredients(updated)
                           }}
                         >
-                          <SelectTrigger className="w-28 h-9 bg-slate-700 border-slate-600 text-white text-sm">
+                          <SelectTrigger className="w-28 h-9 bg-[#F4F4F4] border-[#E0DACE] text-[#222] text-sm">
                             <SelectValue placeholder="Unit" />
                           </SelectTrigger>
                           <SelectContent>
@@ -306,7 +306,7 @@ function RecipeDetailPage() {
                             setEditIngredients(updated)
                           }}
                         >
-                          <SelectTrigger className="w-36 h-9 bg-slate-700 border-slate-600 text-white text-sm">
+                          <SelectTrigger className="w-36 h-9 bg-[#F4F4F4] border-[#E0DACE] text-[#222] text-sm">
                             <SelectValue placeholder="Category" />
                           </SelectTrigger>
                           <SelectContent>
@@ -334,7 +334,7 @@ function RecipeDetailPage() {
                           { name: '', unit: '', amount: 0, category: 'Other', excluded_from_list: false },
                         ])
                       }
-                      className="gap-1.5 text-slate-400 hover:text-white"
+                      className="gap-1.5 text-[#8E8E8E] hover:text-[#222]"
                     >
                       <Plus className="size-3.5" />
                       Add ingredient
@@ -346,11 +346,11 @@ function RecipeDetailPage() {
                       <li
                         key={i}
                         className={`text-sm flex items-center gap-2 ${
-                          ing.excluded_from_list ? 'opacity-40' : 'text-slate-300'
+                          ing.excluded_from_list ? 'opacity-40' : 'text-[#444]'
                         }`}
                       >
                         <span className="flex-1">{ing.name}</span>
-                        <span className="text-white font-medium shrink-0">
+                        <span className="text-[#222] font-medium shrink-0">
                           {ing.amount} {ing.unit}
                         </span>
                         <button
@@ -360,7 +360,7 @@ function RecipeDetailPage() {
                               excluded: !ing.excluded_from_list,
                             })
                           }
-                          className="shrink-0 text-slate-500 hover:text-slate-300 transition-colors cursor-pointer"
+                          className="shrink-0 text-[#ADADAD] hover:text-[#8E8E8E] transition-colors cursor-pointer"
                           title={ing.excluded_from_list ? 'Include in shopping list' : 'Exclude from shopping list'}
                         >
                           {ing.excluded_from_list ? (
@@ -377,14 +377,14 @@ function RecipeDetailPage() {
 
               {/* Instructions */}
               <div>
-                <h3 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-3">
+                <h3 className="text-xs font-semibold text-[#8E8E8E] uppercase tracking-wider mb-3">
                   Instructions
                 </h3>
                 {editing ? (
                   <div className="space-y-2">
                     {editInstructions.map((step, i) => (
                       <div key={i} className="flex items-start gap-2">
-                        <span className="text-slate-500 font-mono text-sm pt-2.5 shrink-0">{i + 1}.</span>
+                        <span className="text-[#ADADAD] font-mono text-sm pt-2.5 shrink-0">{i + 1}.</span>
                         <textarea
                           value={step}
                           onChange={(e) => {
@@ -393,7 +393,7 @@ function RecipeDetailPage() {
                             setEditInstructions(updated)
                           }}
                           rows={2}
-                          className="flex-1 bg-slate-700 border border-slate-600 rounded-md px-3 py-2 text-sm text-white resize-none focus:outline-none focus:ring-2 focus:ring-slate-500"
+                          className="flex-1 bg-[#F4F4F4] border border-[#E0DACE] rounded-md px-3 py-2 text-sm text-[#222] resize-none focus:outline-none focus:ring-2 focus:ring-[#FFB951]"
                         />
                         <div className="flex flex-col gap-0.5 shrink-0">
                           <Button
@@ -406,7 +406,7 @@ function RecipeDetailPage() {
                               setEditInstructions(updated)
                             }}
                             disabled={i === 0}
-                            className="size-7 text-slate-500 hover:text-white"
+                            className="size-7 text-[#ADADAD] hover:text-[#222]"
                           >
                             <ArrowUp className="size-3.5" />
                           </Button>
@@ -420,7 +420,7 @@ function RecipeDetailPage() {
                               setEditInstructions(updated)
                             }}
                             disabled={i === editInstructions.length - 1}
-                            className="size-7 text-slate-500 hover:text-white"
+                            className="size-7 text-[#ADADAD] hover:text-[#222]"
                           >
                             <ArrowDown className="size-3.5" />
                           </Button>
@@ -439,7 +439,7 @@ function RecipeDetailPage() {
                       variant="ghost"
                       size="sm"
                       onClick={() => setEditInstructions([...editInstructions, ''])}
-                      className="gap-1.5 text-slate-400 hover:text-white"
+                      className="gap-1.5 text-[#8E8E8E] hover:text-[#222]"
                     >
                       <Plus className="size-3.5" />
                       Add step
@@ -448,8 +448,8 @@ function RecipeDetailPage() {
                 ) : (
                   <ol className="space-y-2.5">
                     {recipe.instructions.map((step, i) => (
-                      <li key={i} className="text-sm text-slate-300 flex gap-3">
-                        <span className="text-slate-500 font-mono shrink-0 pt-px">{i + 1}.</span>
+                      <li key={i} className="text-sm text-[#444] flex gap-3">
+                        <span className="text-[#ADADAD] font-mono shrink-0 pt-px">{i + 1}.</span>
                         <span>{highlightAmounts(step)}</span>
                       </li>
                     ))}

--- a/client/src/routes/recipes.tsx
+++ b/client/src/routes/recipes.tsx
@@ -63,12 +63,12 @@ function RecipeList() {
     ratingMutation.mutate({ id, rating })
 
   return (
-    <div className="min-h-screen bg-linear-to-b from-slate-900 via-slate-800 to-slate-900 text-white">
+    <div className="min-h-screen bg-[#F4F4F4] text-[#222]">
       <div className="max-w-5xl mx-auto px-4 py-12">
         <div className="flex items-center justify-between mb-8">
           <h1 className="text-2xl font-bold tracking-tight">My Recipes</h1>
           {recipes && recipes.length > 0 && (
-            <div className="flex items-center gap-1 rounded-lg border border-slate-700 bg-slate-800 p-1">
+            <div className="flex items-center gap-1 rounded-lg border border-[#E8E4DC] bg-white p-1">
               <Button
                 type="button"
                 variant="ghost"
@@ -77,8 +77,8 @@ function RecipeList() {
                 aria-pressed={view === 'list'}
                 onClick={() => setView('list')}
                 className={cn(
-                  'text-slate-400 hover:text-white',
-                  view === 'list' && 'bg-slate-700 text-white',
+                  'text-[#8E8E8E] hover:text-[#222]',
+                  view === 'list' && 'bg-[#F0EDE6] text-[#222]',
                 )}
               >
                 <List />
@@ -91,8 +91,8 @@ function RecipeList() {
                 aria-pressed={view === 'grid'}
                 onClick={() => setView('grid')}
                 className={cn(
-                  'text-slate-400 hover:text-white',
-                  view === 'grid' && 'bg-slate-700 text-white',
+                  'text-[#8E8E8E] hover:text-[#222]',
+                  view === 'grid' && 'bg-[#F0EDE6] text-[#222]',
                 )}
               >
                 <LayoutGrid />
@@ -102,7 +102,7 @@ function RecipeList() {
         </div>
 
         {isLoading && (
-          <div className="flex items-center gap-2 text-slate-400">
+          <div className="flex items-center gap-2 text-[#8E8E8E]">
             <Loader2 className="size-5 animate-spin" />
             Loading recipes...
           </div>
@@ -110,10 +110,10 @@ function RecipeList() {
 
         {recipes && recipes.length === 0 && (
           <div className="text-center py-16">
-            <p className="text-slate-400 mb-4">No recipes yet.</p>
+            <p className="text-[#8E8E8E] mb-4">No recipes yet.</p>
             <Link
               to="/"
-              className="text-sm text-slate-300 hover:text-white underline underline-offset-4 transition-colors"
+              className="text-sm text-[#444] hover:text-[#222] underline underline-offset-4 transition-colors"
             >
               Create your first recipe
             </Link>
@@ -150,12 +150,12 @@ function RecipeList() {
 
 function RecipeMeta({ recipe }: { recipe: RecipeSummary }) {
   return (
-    <div className="flex items-center gap-3 mt-1.5 text-sm text-slate-400">
+    <div className="flex items-center gap-3 mt-1.5 text-sm text-[#8E8E8E]">
       <span>
         {recipe.ingredient_count} ingredient
         {recipe.ingredient_count !== 1 ? 's' : ''}
       </span>
-      <span className="text-slate-600">·</span>
+      <span className="text-[#CFCFCF]">·</span>
       <span>
         {recipe.created_at
           ? new Date(recipe.created_at).toLocaleDateString()
@@ -172,12 +172,12 @@ type RecipeItemProps = {
 
 function RecipeListRow({ recipe, onRate }: RecipeItemProps) {
   return (
-    <div className="bg-slate-800 border border-slate-700 rounded-xl p-5 flex items-center gap-4">
+    <div className="bg-white border border-[#E8E4DC] rounded-xl p-5 flex items-center gap-4 shadow-sm">
       <div className="flex-1 min-w-0">
         <Link
           to="/recipe/$recipeId"
           params={{ recipeId: recipe.id }}
-          className="text-white font-medium hover:underline underline-offset-4"
+          className="text-[#222] font-medium hover:underline underline-offset-4"
         >
           {recipe.title}
         </Link>
@@ -193,12 +193,12 @@ function RecipeListRow({ recipe, onRate }: RecipeItemProps) {
 
 function RecipeGridCard({ recipe, onRate }: RecipeItemProps) {
   return (
-    <div className="bg-slate-800 border border-slate-700 rounded-xl p-5 flex flex-col gap-4 h-full">
+    <div className="bg-white border border-[#E8E4DC] rounded-xl p-5 flex flex-col gap-4 h-full shadow-sm">
       <div className="flex-1 min-w-0">
         <Link
           to="/recipe/$recipeId"
           params={{ recipeId: recipe.id }}
-          className="text-white font-medium hover:underline underline-offset-4"
+          className="text-[#222] font-medium hover:underline underline-offset-4"
         >
           {recipe.title}
         </Link>

--- a/client/src/routes/recipes.tsx
+++ b/client/src/routes/recipes.tsx
@@ -63,12 +63,12 @@ function RecipeList() {
     ratingMutation.mutate({ id, rating })
 
   return (
-    <div className="min-h-screen bg-[#F4F4F4] text-[#222]">
+    <div className="min-h-screen bg-cream text-ink">
       <div className="max-w-5xl mx-auto px-4 py-12">
         <div className="flex items-center justify-between mb-8">
           <h1 className="text-2xl font-bold tracking-tight">My Recipes</h1>
           {recipes && recipes.length > 0 && (
-            <div className="flex items-center gap-1 rounded-lg border border-[#E8E4DC] bg-white p-1">
+            <div className="flex items-center gap-1 rounded-lg border border-line bg-white p-1">
               <Button
                 type="button"
                 variant="ghost"
@@ -77,8 +77,8 @@ function RecipeList() {
                 aria-pressed={view === 'list'}
                 onClick={() => setView('list')}
                 className={cn(
-                  'text-[#8E8E8E] hover:text-[#222]',
-                  view === 'list' && 'bg-[#F0EDE6] text-[#222]',
+                  'text-ink-muted hover:text-ink',
+                  view === 'list' && 'bg-sand text-ink',
                 )}
               >
                 <List />
@@ -91,8 +91,8 @@ function RecipeList() {
                 aria-pressed={view === 'grid'}
                 onClick={() => setView('grid')}
                 className={cn(
-                  'text-[#8E8E8E] hover:text-[#222]',
-                  view === 'grid' && 'bg-[#F0EDE6] text-[#222]',
+                  'text-ink-muted hover:text-ink',
+                  view === 'grid' && 'bg-sand text-ink',
                 )}
               >
                 <LayoutGrid />
@@ -102,7 +102,7 @@ function RecipeList() {
         </div>
 
         {isLoading && (
-          <div className="flex items-center gap-2 text-[#8E8E8E]">
+          <div className="flex items-center gap-2 text-ink-muted">
             <Loader2 className="size-5 animate-spin" />
             Loading recipes...
           </div>
@@ -110,10 +110,10 @@ function RecipeList() {
 
         {recipes && recipes.length === 0 && (
           <div className="text-center py-16">
-            <p className="text-[#8E8E8E] mb-4">No recipes yet.</p>
+            <p className="text-ink-muted mb-4">No recipes yet.</p>
             <Link
               to="/"
-              className="text-sm text-[#444] hover:text-[#222] underline underline-offset-4 transition-colors"
+              className="text-sm text-ink-soft hover:text-ink underline underline-offset-4 transition-colors"
             >
               Create your first recipe
             </Link>
@@ -150,12 +150,12 @@ function RecipeList() {
 
 function RecipeMeta({ recipe }: { recipe: RecipeSummary }) {
   return (
-    <div className="flex items-center gap-3 mt-1.5 text-sm text-[#8E8E8E]">
+    <div className="flex items-center gap-3 mt-1.5 text-sm text-ink-muted">
       <span>
         {recipe.ingredient_count} ingredient
         {recipe.ingredient_count !== 1 ? 's' : ''}
       </span>
-      <span className="text-[#CFCFCF]">·</span>
+      <span className="text-ink-subtle">·</span>
       <span>
         {recipe.created_at
           ? new Date(recipe.created_at).toLocaleDateString()
@@ -172,12 +172,12 @@ type RecipeItemProps = {
 
 function RecipeListRow({ recipe, onRate }: RecipeItemProps) {
   return (
-    <div className="bg-white border border-[#E8E4DC] rounded-xl p-5 flex items-center gap-4 shadow-sm">
+    <div className="bg-white border border-line rounded-xl p-5 flex items-center gap-4 shadow-sm">
       <div className="flex-1 min-w-0">
         <Link
           to="/recipe/$recipeId"
           params={{ recipeId: recipe.id }}
-          className="text-[#222] font-medium hover:underline underline-offset-4"
+          className="text-ink font-medium hover:underline underline-offset-4"
         >
           {recipe.title}
         </Link>
@@ -193,12 +193,12 @@ function RecipeListRow({ recipe, onRate }: RecipeItemProps) {
 
 function RecipeGridCard({ recipe, onRate }: RecipeItemProps) {
   return (
-    <div className="bg-white border border-[#E8E4DC] rounded-xl p-5 flex flex-col gap-4 h-full shadow-sm">
+    <div className="bg-white border border-line rounded-xl p-5 flex flex-col gap-4 h-full shadow-sm">
       <div className="flex-1 min-w-0">
         <Link
           to="/recipe/$recipeId"
           params={{ recipeId: recipe.id }}
-          className="text-[#222] font-medium hover:underline underline-offset-4"
+          className="text-ink font-medium hover:underline underline-offset-4"
         >
           {recipe.title}
         </Link>

--- a/client/src/routes/settings.tsx
+++ b/client/src/routes/settings.tsx
@@ -85,20 +85,20 @@ function SettingsPage() {
   }
 
   return (
-    <div className="min-h-screen bg-[#F4F4F4] text-[#222]">
+    <div className="min-h-screen bg-cream text-ink">
       <div className="max-w-lg mx-auto px-4 py-12">
         <h1 className="text-2xl font-bold mb-8">Settings</h1>
 
         <div className="space-y-6">
           <div>
             <h2 className="text-lg font-semibold mb-1">Categories</h2>
-            <p className="text-sm text-[#8E8E8E] mb-4">
+            <p className="text-sm text-ink-muted mb-4">
               Manage how items are grouped on your shopping lists. Drag to reorder.
             </p>
 
             {isLoading && (
               <div className="flex justify-center py-8">
-                <Loader2 className="size-6 animate-spin text-[#8E8E8E]" />
+                <Loader2 className="size-6 animate-spin text-ink-muted" />
               </div>
             )}
 
@@ -107,9 +107,9 @@ function SettingsPage() {
                 {sorted.map((cat, index) => (
                   <div
                     key={cat.name}
-                    className="flex items-center gap-2 bg-white border border-[#E8E4DC] rounded-md px-3 py-2.5 shadow-sm"
+                    className="flex items-center gap-2 bg-white border border-line rounded-md px-3 py-2.5 shadow-sm"
                   >
-                    <GripVertical className="size-4 text-[#CFCFCF] shrink-0" />
+                    <GripVertical className="size-4 text-ink-subtle shrink-0" />
 
                     {editingIndex === index ? (
                       <form
@@ -122,7 +122,7 @@ function SettingsPage() {
                         <Input
                           value={editName}
                           onChange={(e) => setEditName(e.target.value)}
-                          className="h-7 bg-[#F4F4F4] border-[#E0DACE] text-[#222] text-sm"
+                          className="h-7 bg-cream border-line-strong text-ink text-sm"
                           autoFocus
                           onKeyDown={(e) => {
                             if (e.key === 'Escape') setEditingIndex(null)
@@ -135,7 +135,7 @@ function SettingsPage() {
                           type="button"
                           variant="ghost"
                           size="sm"
-                          className="h-7 text-[#8E8E8E]"
+                          className="h-7 text-ink-muted"
                           onClick={() => setEditingIndex(null)}
                         >
                           <X className="size-3.5" />
@@ -150,7 +150,7 @@ function SettingsPage() {
                             size="icon-xs"
                             onClick={() => handleMove(index, 'up')}
                             disabled={index === 0}
-                            className="text-[#8E8E8E] hover:text-[#222]"
+                            className="text-ink-muted hover:text-ink"
                           >
                             <ArrowUp className="size-3.5" />
                           </Button>
@@ -159,7 +159,7 @@ function SettingsPage() {
                             size="icon-xs"
                             onClick={() => handleMove(index, 'down')}
                             disabled={index === sorted.length - 1}
-                            className="text-[#8E8E8E] hover:text-[#222]"
+                            className="text-ink-muted hover:text-ink"
                           >
                             <ArrowDown className="size-3.5" />
                           </Button>
@@ -170,7 +170,7 @@ function SettingsPage() {
                               setEditingIndex(index)
                               setEditName(cat.name)
                             }}
-                            className="text-[#8E8E8E] hover:text-[#222]"
+                            className="text-ink-muted hover:text-ink"
                           >
                             <Pencil className="size-3.5" />
                           </Button>
@@ -202,7 +202,7 @@ function SettingsPage() {
                 value={newCategoryName}
                 onChange={(e) => setNewCategoryName(e.target.value)}
                 placeholder="New category name..."
-                className="flex-1 bg-white border-[#E8E4DC] text-[#222] placeholder:text-[#ADADAD]"
+                className="flex-1 bg-white border-line text-ink placeholder:text-ink-faint"
               />
               <Button type="submit" disabled={!newCategoryName.trim() || updateCategories.isPending}>
                 <Plus className="size-4" />

--- a/client/src/routes/settings.tsx
+++ b/client/src/routes/settings.tsx
@@ -85,20 +85,20 @@ function SettingsPage() {
   }
 
   return (
-    <div className="min-h-screen bg-linear-to-b from-slate-900 via-slate-800 to-slate-900 text-white">
+    <div className="min-h-screen bg-[#F4F4F4] text-[#222]">
       <div className="max-w-lg mx-auto px-4 py-12">
         <h1 className="text-2xl font-bold mb-8">Settings</h1>
 
         <div className="space-y-6">
           <div>
             <h2 className="text-lg font-semibold mb-1">Categories</h2>
-            <p className="text-sm text-slate-400 mb-4">
+            <p className="text-sm text-[#8E8E8E] mb-4">
               Manage how items are grouped on your shopping lists. Drag to reorder.
             </p>
 
             {isLoading && (
               <div className="flex justify-center py-8">
-                <Loader2 className="size-6 animate-spin text-slate-400" />
+                <Loader2 className="size-6 animate-spin text-[#8E8E8E]" />
               </div>
             )}
 
@@ -107,9 +107,9 @@ function SettingsPage() {
                 {sorted.map((cat, index) => (
                   <div
                     key={cat.name}
-                    className="flex items-center gap-2 bg-slate-800 border border-slate-700 rounded-md px-3 py-2.5"
+                    className="flex items-center gap-2 bg-white border border-[#E8E4DC] rounded-md px-3 py-2.5 shadow-sm"
                   >
-                    <GripVertical className="size-4 text-slate-600 shrink-0" />
+                    <GripVertical className="size-4 text-[#CFCFCF] shrink-0" />
 
                     {editingIndex === index ? (
                       <form
@@ -122,7 +122,7 @@ function SettingsPage() {
                         <Input
                           value={editName}
                           onChange={(e) => setEditName(e.target.value)}
-                          className="h-7 bg-slate-700 border-slate-600 text-white text-sm"
+                          className="h-7 bg-[#F4F4F4] border-[#E0DACE] text-[#222] text-sm"
                           autoFocus
                           onKeyDown={(e) => {
                             if (e.key === 'Escape') setEditingIndex(null)
@@ -135,7 +135,7 @@ function SettingsPage() {
                           type="button"
                           variant="ghost"
                           size="sm"
-                          className="h-7 text-slate-400"
+                          className="h-7 text-[#8E8E8E]"
                           onClick={() => setEditingIndex(null)}
                         >
                           <X className="size-3.5" />
@@ -150,7 +150,7 @@ function SettingsPage() {
                             size="icon-xs"
                             onClick={() => handleMove(index, 'up')}
                             disabled={index === 0}
-                            className="text-slate-500 hover:text-white"
+                            className="text-[#8E8E8E] hover:text-[#222]"
                           >
                             <ArrowUp className="size-3.5" />
                           </Button>
@@ -159,7 +159,7 @@ function SettingsPage() {
                             size="icon-xs"
                             onClick={() => handleMove(index, 'down')}
                             disabled={index === sorted.length - 1}
-                            className="text-slate-500 hover:text-white"
+                            className="text-[#8E8E8E] hover:text-[#222]"
                           >
                             <ArrowDown className="size-3.5" />
                           </Button>
@@ -170,7 +170,7 @@ function SettingsPage() {
                               setEditingIndex(index)
                               setEditName(cat.name)
                             }}
-                            className="text-slate-500 hover:text-white"
+                            className="text-[#8E8E8E] hover:text-[#222]"
                           >
                             <Pencil className="size-3.5" />
                           </Button>
@@ -202,7 +202,7 @@ function SettingsPage() {
                 value={newCategoryName}
                 onChange={(e) => setNewCategoryName(e.target.value)}
                 placeholder="New category name..."
-                className="flex-1 bg-slate-800 border-slate-700 text-white placeholder:text-slate-500"
+                className="flex-1 bg-white border-[#E8E4DC] text-[#222] placeholder:text-[#ADADAD]"
               />
               <Button type="submit" disabled={!newCategoryName.trim() || updateCategories.isPending}>
                 <Plus className="size-4" />


### PR DESCRIPTION
Switch the client's visual theme to match the Omlete v3 design: warm cream (`#F4F4F4`) backgrounds, white cards, amber (`#FFB951`) primary accent, and DM Sans headings.

## Changes
- **`index.css`**: Recolors the theme tokens (`--background`, `--primary`, `--accent`, etc.) to warm cream + amber, and imports the DM Sans font.
- **`__root.tsx`**: Removes the forced `dark` class on `<html>`, drops the dark body background, recolors the desktop/mobile nav, and adds DM Sans `<link>` tags.
- **Routes** (`create`, `index`, `list.$listId`, `recipe.$recipeId`, `recipes`, `settings`): Recolors backgrounds, cards, inputs, borders, progress bars, and text from slate → cream/amber.
- **Shared components** (`RecipeCard.tsx`, `highlightAmounts.tsx`): Updated to light theme colors.

No functional changes — purely visual.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01Ryrqj2XbkS8uWVfKeLSMts

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ryrqj2XbkS8uWVfKeLSMts)_