### PR TITLE
Improve recipe display and list naming on home page

### DIFF
--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -1,8 +1,13 @@
-import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Copy, Loader2, Plus, ShoppingCart, Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { apiFetch } from '@/lib/api'
+
+type RecipeSummary = {
+  id: string
+  title: string
+}
 
 type ListSummary = {
   id: string
@@ -10,7 +15,7 @@ type ListSummary = {
   created_at: string | null
   item_count: number
   checked_count: number
-  recipe_titles: string[]
+  recipes: RecipeSummary[]
 }
 
 export const Route = createFileRoute('/')({ component: ListsPage })
@@ -95,10 +100,10 @@ function ListsPage() {
         {lists && lists.length > 0 && (
           <div className="space-y-3">
             {lists.map((list) => (
-              <button
+              <div
                 key={list.id}
-                onClick={() => navigate({ to: '/list/$listId', params: { listId: list.id } })}
                 className="w-full text-left bg-white border border-line rounded-lg p-4 shadow-sm hover:shadow-md hover:border-primary transition-all cursor-pointer"
+                onClick={() => navigate({ to: '/list/$listId', params: { listId: list.id } })}
               >
                 <div className="flex items-center justify-between mb-1">
                   <h2 className="font-medium">{list.name}</h2>
@@ -117,18 +122,23 @@ function ListsPage() {
                   </div>
                 )}
 
-                {list.recipe_titles.length > 0 && (
-                  <p className="text-sm text-ink-muted truncate">
-                    {list.recipe_titles.join(', ')}
-                  </p>
+                {list.recipes.length > 0 && (
+                  <div className="flex flex-wrap gap-1.5 mt-2">
+                    {list.recipes.map((recipe) => (
+                      <Link
+                        key={recipe.id}
+                        to="/recipe/$recipeId"
+                        params={{ recipeId: recipe.id }}
+                        onClick={(e) => e.stopPropagation()}
+                        className="inline-block text-xs px-2.5 py-1 rounded-full bg-cream text-ink-muted hover:bg-sand hover:text-ink transition-colors truncate max-w-[180px]"
+                      >
+                        {recipe.title}
+                      </Link>
+                    ))}
+                  </div>
                 )}
 
-                <div className="flex items-center justify-between mt-2">
-                  {list.created_at && (
-                    <p className="text-xs text-ink-faint">
-                      {new Date(list.created_at).toLocaleDateString()}
-                    </p>
-                  )}
+                <div className="flex items-center justify-end mt-3">
                   <div className="flex gap-1">
                     <Button
                       variant="ghost"
@@ -160,7 +170,7 @@ function ListsPage() {
                     </Button>
                   </div>
                 </div>
-              </button>
+              </div>
             ))}
           </div>
         )}

--- a/server/main.py
+++ b/server/main.py
@@ -342,11 +342,18 @@ async def get_units():
 # --- Lists ---
 
 
+def _ordinal(n: int) -> str:
+    if 11 <= n % 100 <= 13:
+        suffix = "th"
+    else:
+        suffix = {1: "st", 2: "nd", 3: "rd"}.get(n % 10, "th")
+    return f"{n}{suffix}"
+
+
 def _auto_list_name() -> str:
-    from datetime import datetime, timezone, timedelta
+    from datetime import datetime, timezone
     now = datetime.now(timezone.utc)
-    monday = now - timedelta(days=now.weekday())
-    return f"Week of {monday.strftime('%b %d')}"
+    return f"{_ordinal(now.day)} {now.strftime('%B')}"
 
 
 @router.get("/lists/")
@@ -354,18 +361,18 @@ async def get_lists():
     lists = await ListDocument.find_all().sort("-created_at").to_list()
     results = []
     for lst in lists:
-        recipe_titles = []
+        recipes_summary = []
         if lst.recipes:
             oids = [PydanticObjectId(rid) for rid in lst.recipes]
             recipes = await RecipeDocument.find(In(RecipeDocument.id, oids)).to_list()
-            recipe_titles = [r.title for r in recipes]
+            recipes_summary = [{"id": str(r.id), "title": r.title} for r in recipes]
         results.append({
             "id": str(lst.id),
             "name": lst.name,
             "created_at": lst.created_at.isoformat() if lst.created_at else None,
             "item_count": len(lst.items),
             "checked_count": sum(1 for item in lst.items if item.checked),
-            "recipe_titles": recipe_titles,
+            "recipes": recipes_summary,
         })
     return results
 


### PR DESCRIPTION
## Summary
Enhanced the lists page UI to display recipes as interactive badge links instead of plain text, and updated the auto-generated list naming convention to use ordinal dates.

## Key Changes

**Frontend (`client/src/routes/index.tsx`)**
- Updated `ListSummary` type to include `recipes` as an array of `RecipeSummary` objects (with `id` and `title`) instead of `recipe_titles` string array
- Changed list container from `<button>` to `<div>` for better semantic HTML structure
- Replaced plain text recipe display with interactive badge-style links:
  - Recipes now render as clickable pills with `Link` components
  - Added `onClick` event propagation stop to prevent navigating to the list when clicking a recipe
  - Styled with cream background, hover effects, and truncation for long titles
- Removed created date display from the list footer
- Adjusted layout spacing and alignment of action buttons

**Backend (`server/main.py`)**
- Added `_ordinal()` helper function to convert integers to ordinal format (1st, 2nd, 3rd, etc.)
- Updated `_auto_list_name()` to generate names using ordinal dates (e.g., "15th December") instead of week-based naming
- Modified `get_lists()` endpoint to return recipe data as structured objects with `id` and `title` fields instead of a flat list of titles
  - Changed response field from `recipe_titles` to `recipes`

## Implementation Details
- Recipe links include `e.stopPropagation()` to prevent unintended navigation when clicking recipe badges
- Recipe badges have a max-width constraint (`max-w-[180px]`) with truncation to handle long recipe titles
- The ordinal naming convention provides more granular list identification compared to the previous week-based approach

https://claude.ai/code/session_01VEGKjWKmn6cBGxkHUWjR5L