### PR TITLE
docs: Add PRD for URL import and competitive analysis

### DIFF
--- a/docs/GAP_ANALYSIS.md
+++ b/docs/GAP_ANALYSIS.md
@@ -1,0 +1,291 @@
+# Omlete — Codebase Audit & Competitive Gap Analysis
+
+_July 2026. Based on `main` @ `9ec7077`._
+
+---
+
+## 1. What Omlete actually is today
+
+Stripped of the marketing, Omlete is **a shopping-list app with an AI recipe importer attached**. That's a real product, and the shopping-list half is genuinely good. But it is not, today, a recipe manager — and the README/CLAUDE.md describe an app that doesn't exist (they still reference Render, a `/meal-plan` route, and `POST /meal-plan/shopping-list/`, none of which are in the codebase).
+
+### What's genuinely strong
+
+| Thing | Why it's good |
+|---|---|
+| **Ingredient canonicalisation via embeddings** (`ingredient_service.py`, `tools.py`) | Voyage-4 2048-dim embeddings + Mongo `$vectorSearch` at ≥0.9, exposed to Claude as a tool so the model reconciles "spring onions" against your existing library at generation time. **Nobody in the competitive set does this.** This is the most interesting thing in the repo. |
+| **Shopping list source tracking** (`ItemSource`, `main.py:519-595`) | Items remember which recipes contributed which amounts, so removing a recipe subtracts exactly its share and drops the item only when nothing else needs it. Paprika and AnyList do *not* do this cleanly — they merge and forget. |
+| **Plan vs Shop modes** (`list.$listId.tsx:389-406`) | Same data, two layouts, sensible default. Genuinely thoughtful. |
+| **Optimistic mutations + drag reorder** | The list page is the most polished surface in the app. |
+| **Multi-photo → single recipe extraction** | Handles the real case of a cookbook spread across two pages. Most competitors treat each photo as one recipe. |
+| **Editable categories with custom aisle order** | Matches AnyList/Tandoor. Table stakes, and you have it. |
+
+### The data model, in full
+
+```python
+Recipe   = title + instructions[]                       # lib/types.py:33
+Ingredient = name + unit + amount + category + excluded_from_list
+RecipeDocument = Recipe + ingredients[] + rating + created_at
+```
+
+**That's it.** No servings, no prep/cook time, no photo, no source URL, no tags, no cuisine, no notes, no nutrition, no difficulty, no yield. Verified: `grep -riE "servings|prep_time|cook_time|tags|image_url|source_url|nutrition|calories"` returns **zero hits** across `server/` and `client/src/`.
+
+Every gap below flows from that one line.
+
+---
+
+## 2. The competitive landscape
+
+Three cohorts, and Omlete is currently competitive with none of them.
+
+**Cohort A — Classic managers.** [Paprika](https://www.paprikaapp.com/) (URL import, pantry with expiry tracking, daily/weekly/monthly meal planner, reusable menus, scaling + unit conversion, cook mode, cross-device sync), [Mela](https://mela.recipes/) (Apple-only, structured-data import only), [AnyList](https://www.anylist.com/) (real-time shared household lists, aisle ordering, item photos, running price total, recipe import, meal-plan calendar — $9.99/yr). Paprika hasn't shipped a major feature since 2018; the category is stagnant and beatable.
+
+**Cohort B — Self-hosted.** [Mealie and Tandoor](https://cooklang.org/blog/42-tandoor-vs-mealie-vs-kitchenowl/) — both do URL scraping. Tandoor adds OCR for cookbooks, keyword/tag systems, full-text search, iCal meal-plan export, OpenFoodFacts nutrition, barcode scanning, aisle mapping, and meal-cost calculation. This is the closest architectural comparator to what you've built, and Tandoor is well ahead on feature surface.
+
+**Cohort C — AI-native (2024-2026 wave).** ReciMe, Pluck, Recipe Bro, FoodiePrep, Nutrola, CookNest. Their entire pitch is **import from anywhere** — [any website, Instagram, TikTok, YouTube, Pinterest, screenshots](https://recipebro.com/import) — plus auto-derived nutrition and an agentic assistant. [Nutrola](https://nutrola.app/en/blog/best-apps-that-extract-recipes-from-video-urls-2026) pulls full ingredient lists with quantities out of TikTok/Reels/Shorts. This is the cohort Omlete is actually in, and it's the cohort moving fastest.
+
+Separately: [SuperCook](https://apps.apple.com/us/app/supercook-ai-meals-scanner/id6743327665) owns "what can I make with what I have" — a pantry of 2000+ ingredients matched against 11M recipes. That's the closest thing to Omlete's original stated premise ("turn leftover ingredients into a recipe"), and Omlete has **no pantry at all**.
+
+### Feature matrix
+
+| | Omlete | Paprika | AnyList | Tandoor | AI-native cohort |
+|---|:--:|:--:|:--:|:--:|:--:|
+| Import from URL | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Import from photo / OCR | ✅ | ❌ | ❌ | ✅ | ✅ |
+| Import from video / social | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Generate recipe from ingredients | ✅ | ❌ | ❌ | ❌ | ✅ |
+| Recipe photos | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Search / tags / filter | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Servings + scaling | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Prep/cook times | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Meal-plan calendar | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Pantry | ❌ | ✅ | ❌ | ✅ | partial |
+| Cook mode (step tracking, timers) | wake lock only | ✅ | ❌ | ✅ | ✅ |
+| Nutrition | ❌ | ❌ | ❌ | ✅ | ✅ |
+| Shared / household lists | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Offline | ❌ | ✅ | ✅ | ❌ | partial |
+| Aisle-ordered lists | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Ingredient-level dedup across recipes | ✅✅ | partial | partial | partial | ❌ |
+| Semantic ingredient matching | ✅✅ | ❌ | ❌ | ❌ | ❌ |
+
+Two columns where you're **ahead of the entire field**. Ten where you're behind all of it.
+
+---
+
+## 3. The biggest gaps, ranked
+
+### 🔴 Gap 1 — No URL import
+
+**The single highest-leverage missing feature.** Every app in every cohort has it. It is how normal people acquire recipes: they find a link, they paste it. Omlete's only two inputs are "type your ingredients" and "photograph a cookbook" — both are high-effort, low-frequency paths.
+
+The implementation is cheap because you already have every piece:
+
+1. `pip install recipe-scrapers` — [649 supported sites](https://docs.recipe-scrapers.com/), parses JSON-LD, Microdata, RDFa and OpenGraph.
+2. On a hit, you get title, ingredients, instructions, image, times, yield, nutrition — **for free**, no LLM call, no token cost, sub-second.
+3. On a miss, fall back to your existing Claude path with the page text.
+4. Either way, run the result through `find_similar_ingredients` so the ingredients land canonicalised. That's your differentiator applied to the industry-standard input.
+
+You'd match Paprika/Mealie on import in a day or two, and beat them on the ingredient reconciliation.
+
+**Then extend to social video** (yt-dlp → transcript + keyframes → Claude). That's where the AI-native cohort is competing right now and it plays directly to a Claude-backed backend.
+
+### 🔴 Gap 2 — No recipe photos
+
+A recipe library with no images is a text list. This is why `/recipes` grid view (`recipes.tsx:135-145`) looks identical to list view — there's nothing to put in the grid. Users pick what to cook by looking at food.
+
+Note the irony: you upload photos to *create* recipes and then throw them away. `_extract_and_save` (`main.py:176-204`) base64s the image, sends it to Claude, and discards it. Storing that image (or the first one) as the recipe's hero image is nearly free.
+
+### 🔴 Gap 3 — No search, no tags, no filtering
+
+`GET /recipes/` is `RecipeDocument.find_all()` (`main.py:242`) — every recipe, every time, unpaginated, unsorted beyond `created_at`, rendered as a flat list. This is fine at 20 recipes. At 100 it's unusable, at 500 it's a several-hundred-KB payload on every page load of `/recipes`, `/list/$listId`, and the suggest sheet.
+
+You need, in order: text search on title+ingredients (Mongo text index or Atlas Search — you already pay for Atlas), tags/cuisine/meal-type, filter by rating, and pagination. Without this the library is write-only.
+
+### 🟠 Gap 4 — No servings, and therefore no scaling
+
+`Recipe` has no `servings` field, so "scale to 6 people" is impossible, and the shopping-list amounts are meaningless in absolute terms — a recipe adds "500g pasta" with no statement of how many people that feeds. Paprika markets scaling + unit conversion as a headline feature.
+
+This also silently corrupts the list: `add_recipe_to_list` sums raw amounts across recipes with no notion of yield.
+
+### 🟠 Gap 5 — No times or metadata
+
+No prep time, no cook time, no total time, no difficulty. "Quick & easy" exists as a *suggestion filter* (`DIET_OPTIONS`/`EASE_OPTIONS`, `list.$listId.tsx:837-849`) but is never persisted to the recipe, so you can't filter your own library by it. The information is in the model's head at generation time and you're discarding it.
+
+### 🟠 Gap 6 — No meal-plan calendar
+
+Every competitor has one. Your `ListDocument` is *nearly* a meal plan — it has recipes and a date-derived name (`_auto_list_name()`, `main.py:354-357`) — but there's no day assignment, so "Tuesday: chilli" isn't expressible. This is the smallest gap-to-value ratio on the list: add `day` to the list↔recipe relation and you have a week planner.
+
+### 🟠 Gap 7 — No cook mode
+
+You have `useWakeLock` (good, that's the annoying part) but nothing else. Paprika's cook mode: cross off ingredients as you use them, highlight the current step, timers. Yours renders a static `<ol>`. `highlightAmounts.tsx` is a nice touch that's begging to be wired to a step-by-step view with a "start timer" affordance when a step mentions a duration.
+
+### 🟡 Gap 8 — No pantry
+
+The app's origin story is "turn leftover ingredients into a recipe" and there's no representation of what you have. SuperCook's whole business is this. You have the best ingredient vocabulary of anyone (embedded, canonicalised, scored) and no place to say "I own these."
+
+Pantry also closes the loop on the shopping list: check something off → it's in the pantry → next list omits it.
+
+### 🟡 Gap 9 — No auth, no users, no sharing
+
+There is **zero authentication anywhere in the codebase** (verified — no `Depends`, no tokens, no sessions). Consequences:
+
+- Every deployed instance is single-tenant-by-accident: one global recipe pool, one global list pool, one `UserSettingsDocument` (`_get_or_create_settings` does `find_one()` with no filter, `main.py:450-455`).
+- **Household sharing — AnyList's entire value proposition — is unbuildable** without this.
+- See §4; it's also a live cost and abuse problem.
+
+### 🟡 Gap 10 — No offline
+
+`manifest.webmanifest` exists but there is **no service worker** (verified: no `serviceWorker`, no `vite-plugin-pwa`, no `workbox`). So the PWA installs and then shows a blank screen in a supermarket basement with no signal. That's the exact moment the app is most needed. The manifest also still has `background_color`/`theme_color` of `#0f172a` — dark slate, from before the retheme.
+
+---
+
+## 4. Engineering risks that will bite before any of that
+
+These aren't features; they're things that break.
+
+### 🔴 Unauthenticated LLM endpoints = an open wallet
+
+`POST /api/recipes/generate/` and `POST /api/recipes/extract-from-images/` invoke **Claude Opus 4.5** with no auth, no rate limit, no quota, no per-IP throttle. Anyone who finds the Railway URL can run your Anthropic bill up indefinitely, and the image endpoint reads uploads fully into memory (`await file.read()`, `main.py:179`) with no size cap — a large multipart POST is also a straightforward OOM.
+
+CORS (`main.py:59-65`) allows `https://.*\.up\.railway\.app`, which is a wildcard over every app on Railway — but that's moot, because with no auth the API is equally callable by curl.
+
+**Fix before anything else:** an API key or session check on the two Claude endpoints, `slowapi` rate limiting, and a `MAX_UPLOAD_BYTES` guard.
+
+### 🔴 Zero database indexes
+
+No `Indexed()` fields, no `Settings.indexes` on any of the four documents. Concretely:
+
+- `/categorize` (`main.py:476-484`) runs `find_one({"name": {"$regex": "^…$", "$options": "i"}})` against the ingredients collection — an **unanchored-in-practice regex collection scan on every quick-add**, over a collection with 2048-float embeddings in every document. This is the slowest query in the app and it runs on the most latency-sensitive interaction.
+- `IngredientDocument.name` has no unique index, and `_save_recipe` inserts new ingredients with no dedupe check. Two recipes generated in parallel both marking "shallots" as new both insert it. Your canonical ingredient vocabulary drifts.
+
+**Fix:** unique index on lowercased `name`; index `RecipeDocument.created_at`; store a lowercase `name_key` and query on equality instead of regex.
+
+### 🟠 N+1 on the lists page
+
+`GET /lists/` (`main.py:360-378`) loops over every list and issues a separate `RecipeDocument.find(In(...))` per list. Ten lists = eleven round trips on your home screen. Collect all recipe ids, one query, map in memory.
+
+### 🟠 The frontend has no error handling
+
+**No toast, no error banner, no `isError` branch anywhere** in `client/src`. The three `onError` handlers in `list.$listId.tsx` are optimistic-rollback only — they restore state silently and tell the user nothing. Worse, `create.tsx:147-149`:
+
+```ts
+} catch {
+  // Continue with next group on error
+}
+```
+
+A failed extraction is **completely silent** — the spinner advances, the recipe never appears, no explanation. Add `sonner` and surface failures. This is a 30-minute fix with an outsized effect on how the app *feels*.
+
+### 🟠 Long blocking requests with no progress
+
+`runner.until_done()` consumes the stream server-side and returns one JSON blob. A generate is 20-60s of a spinner. Then `handleAddSelected` (`list.$listId.tsx:899-935`) generates selected meals **sequentially** — pick 5 suggestions and you wait 2-5 minutes with a `done/total` counter and no cancel. No client timeout, no retry, no partial results.
+
+Consider SSE with incremental recipe fields, or a job + poll pattern. Also: `suggest_meals` and `categorize` don't need Opus-class reasoning — `suggest_meals` uses Opus 4.5 for five one-line meal ideas (`main.py:166-171`). Move it to Haiku and cut that call's cost by ~95%.
+
+### 🟠 The shopping list merge ignores your best asset
+
+`add_recipe_to_list` (`main.py:540-543`) merges items on `item.name.lower() == ing.name.lower() and item.unit == ing.unit`. Exact string, exact unit. So:
+
+- "spring onions" and "scallions" → two lines
+- "500 g flour" and "2 cups flour" → two lines
+- "garlic clove" and "garlic cloves" → two lines
+
+**You have a semantic ingredient matcher and a vector index sitting right there and you're using `==` on the shopping list.** Fixing this is the clearest expression of your differentiator and it's mostly plumbing you've already written. Pair it with a unit-conversion table (g↔kg, ml↔l, tsp↔tbsp↔cup) and the list gets visibly smarter than Paprika's.
+
+### 🟡 The retheme is half-finished
+
+The `a00628e` cream+amber retheme missed the "Suggest meals" sheet, which is still **entirely on the old dark theme** — `bg-slate-900 border-slate-700 text-white`, `text-emerald-400`, `bg-slate-800` inputs (`list.$listId.tsx:961-1055`). Opening it from a cream page is jarring. Plus scattered leftovers: `border-slate-700` on the Delete button (`recipe.$recipeId.tsx:207`), `text-slate-500 hover:text-red-400` in six files, `border-b border-slate-700/50` (`list.$listId.tsx:706`), and `StarRating` unfilled stars at `text-slate-500` against cream.
+
+### 🟡 Test coverage is ~2% and there's no CI
+
+One backend test file (`tests/test_ingredient_service.py`, 104 lines, covering only `find_similar`). **Zero tests on any of the 25 API endpoints.** Vitest is configured and there are **zero frontend test files**. No `.github/` directory at all — nothing runs on push.
+
+The riskiest untested logic is the list arithmetic: `add_recipe_to_list`/`remove_recipe_from_list` do read-modify-write amount summing across sources, and `reorder_items` has genuinely subtle slot-preservation logic (`main.py:618-639`) mirrored by hand in TypeScript (`list.$listId.tsx:104-116`). Two implementations of the same algorithm in two languages, neither tested.
+
+### 🟡 Docs describe a different app
+
+`README.md` and `CLAUDE.md` both claim Render deployment (you moved to Railway in `71d4f1e`), a `/meal-plan` page, and `POST /meal-plan/suggest/` + `POST /meal-plan/shopping-list/` endpoints. None exist. Anyone onboarding — human or agent — starts from a false map.
+
+---
+
+## 5. Where Omlete can actually win
+
+Don't try to out-feature Paprika. Pick the thing nobody else has and push it hard.
+
+**The semantic ingredient graph is the moat.** Every competitor treats ingredients as strings. You treat them as embedded entities with a canonical vocabulary that grows as you cook. Things that unlocks, roughly in order of effort:
+
+1. **Semantic list merging** (§4) — immediate, visible, uses code you've already written.
+2. **Pantry with fuzzy matching** — "I have scallions" satisfies a recipe calling for spring onions. SuperCook can't do this; they use a fixed 2000-item taxonomy.
+3. **"What can I make?"** — vector-match pantry contents against your recipe library, rank by coverage, show "you're 2 ingredients away from X." This is the app's original premise, finally delivered.
+4. **Substitutions** — "no crème fraîche" → nearest neighbours in embedding space, filtered by what's in the pantry.
+5. **Waste-driven suggestions** — items that have sat unchecked on lists, or pantry items by age, feed into `suggest_meals` as a bias. That's a real, defensible reason to open the app on a Tuesday.
+
+None of these are buildable without the boring work in §3 and §4 first. But they're the reason to do that work.
+
+---
+
+## 6. Recommended sequence
+
+**Phase 0 — Stop the bleeding (days)**
+- Auth on the Claude endpoints + rate limiting + upload size cap
+- Database indexes (unique lowercase ingredient name; `created_at`)
+- Error toasts on the frontend
+- Fix the N+1 in `GET /lists/`
+- Move `suggest_meals` and `categorize` off Opus
+- Update README/CLAUDE.md to match reality
+- A GitHub Actions workflow running pytest + vitest + lint
+
+**Phase 1 — Become a recipe manager (2-3 weeks)**
+- **URL import** via `recipe-scrapers` with Claude fallback ← *the big one*
+- Extend `Recipe`: `servings`, `prep_minutes`, `cook_minutes`, `tags[]`, `image_url`, `source_url`, `notes`
+- Persist the extraction photo as the hero image
+- Search + tag filter + pagination on `/recipes`
+- Backfill: one-off script to have Claude infer the new fields for existing recipes
+
+**Phase 2 — Cooking and planning (2-3 weeks)**
+- Servings + scaling (recompute amounts, scale list contributions)
+- Cook mode: step tracking, ingredient check-off, timers from step text
+- Meal-plan calendar (day assignment on the existing list↔recipe relation)
+- Service worker for offline list access
+
+**Phase 3 — The moat (ongoing)**
+- Semantic + unit-aware list merging
+- Pantry
+- "What can I make?" / substitutions / waste-driven suggestions
+- Social-video import
+- Multi-user + household sharing (needs Phase 0 auth as its foundation)
+
+---
+
+## Appendix — file reference
+
+| Finding | Location |
+|---|---|
+| Recipe model missing all metadata | `server/lib/types.py:33-39` |
+| No indexes on any document | `server/data_models/__init__.py:11-77` |
+| CORS wildcard over Railway | `server/main.py:59-65` |
+| Unauthenticated Opus endpoint | `server/main.py:115-135` |
+| Opus used for one-line suggestions | `server/main.py:166-171` |
+| Uncapped in-memory image read | `server/main.py:179` |
+| Unpaginated `find_all()` | `server/main.py:242` |
+| N+1 on lists | `server/main.py:360-378` |
+| Regex collection scan on categorize | `server/main.py:476-484` |
+| Exact-string list merge | `server/main.py:540-543` |
+| Untested reorder slot logic (Python) | `server/main.py:618-639` |
+| Untested reorder slot logic (TS mirror) | `client/src/routes/list.$listId.tsx:104-116` |
+| Silently swallowed extraction errors | `client/src/routes/create.tsx:147-149` |
+| Dark-theme "Suggest meals" sheet | `client/src/routes/list.$listId.tsx:961-1055` |
+| Stale dark theme colours in manifest | `client/public/manifest.webmanifest` |
+
+## Sources
+
+- [Paprika Recipe Manager](https://www.paprikaapp.com/)
+- [AnyList](https://www.anylist.com/)
+- [Best Recipe Management Software 2026 — Cooklang](https://cooklang.org/blog/48-best-recipe-management-software/)
+- [Tandoor vs Mealie vs KitchenOwl — Cooklang](https://cooklang.org/blog/42-tandoor-vs-mealie-vs-kitchenowl/)
+- [recipe-scrapers documentation](https://docs.recipe-scrapers.com/)
+- [Recipe structured data — Google Search Central](https://developers.google.com/search/docs/appearance/structured-data/recipe)
+- [schema.org/Recipe](https://schema.org/Recipe)
+- [Recipe Bro — import from web and social](https://recipebro.com/import)
+- [Best apps that extract recipes from video URLs 2026 — Nutrola](https://nutrola.app/en/blog/best-apps-that-extract-recipes-from-video-urls-2026)
+- [SuperCook](https://apps.apple.com/us/app/supercook-ai-meals-scanner/id6743327665)
+- [Instacart Developer Platform — shopping list page](https://docs.instacart.com/developer_platform_api/guide/concepts/shopping_list/)

--- a/docs/PRD_URL_IMPORT.md
+++ b/docs/PRD_URL_IMPORT.md
@@ -126,12 +126,14 @@ async def fetch_page(url: str) -> str        # SSRF-guarded async fetch
 def scrape(html: str, url: str) -> ScrapedRecipe | None   # wild_mode=True
 ```
 
-**SSRF guard — required, not optional.** This endpoint takes a user-supplied URL and makes the server fetch it. Without a guard it's a hole straight into the internal network. Must:
+**SSRF guard — required, not optional.** This endpoint takes a user-supplied URL and makes the server fetch it, then returns the parsed result to the caller. That is a textbook full-read SSRF primitive. See [Appendix A](#appendix-a--ssrf-in-detail) for the full threat model, why the obvious mitigations fail, and a reference implementation.
 
-- Allow only `http`/`https` schemes
-- Resolve the hostname and **reject private/reserved ranges**: `127.0.0.0/8`, `10/8`, `172.16/12`, `192.168/16`, `169.254/16` (cloud metadata — `169.254.169.254` is the one that matters), `::1`, unique-local v6
-- Re-check after **every redirect**, cap redirects at ~5
-- Cap response size (~2 MB) and timeout (~10s)
+Summary of what the guard must do:
+
+- Allow only `http` / `https` schemes
+- Resolve the hostname and reject **every** returned address that is loopback, private, link-local, reserved, multicast or unspecified — checked with `ipaddress`, not string matching
+- Disable automatic redirects and **re-validate every hop**, capped at ~5
+- Cap response size (~2 MB, enforced while streaming) and total timeout (~10s)
 - Send a real User-Agent; many sites 403 a default `python-httpx`
 
 `httpx==0.28.1` is already in `requirements.txt`, so use `httpx.AsyncClient` rather than `scrape_me()` — the latter fetches synchronously and would block the event loop.
@@ -209,7 +211,7 @@ Index `source_url` and return 409 with the existing recipe id on re-import. Requ
 | Import the site's rating? | **No** | It's the crowd's rating, not the user's. Our `rating` field means "did *I* like it" |
 | Import nutrition? | **No, not yet** | Returns unparsed strings; out of scope per #50 |
 | Hero image | Store the URL, don't re-host | Cheap. Hotlinks can rot — re-hosting is a later improvement |
-| Save directly or preview first? | **Preview, then save** | See open question 1 — recommended but costs an extra step |
+| Save directly or preview first? | **Save immediately** | Consistent with the existing generate and extract flows. Recipes are editable and deletable, so a bad import is cheap to fix |
 | Default Create tab | From link | Will be the most-used path |
 | robots.txt | Ignore, but always store `source_url` | User is importing a page they're already viewing; attribution is the right etiquette |
 
@@ -280,7 +282,162 @@ Index `source_url` and return 409 with the existing recipe id on re-import. Requ
 
 ## Open questions
 
-1. **Preview before save, or save immediately?** The existing extract flow saves immediately. Preview is better UX — Paprika does it, and it stops bad imports polluting the library — but it's an extra screen and an extra state. *Recommendation: preview.* Import quality varies too much across sites to save blind.
+1. ~~**Preview before save, or save immediately?**~~ **Resolved: save immediately**, matching the existing generate and extract flows. Imports land straight in the library; the user edits or deletes if the import was poor.
 2. **What do we do about `amount` on unquantified ingredients?** `IngredientRecipe.amount` is currently a **required `float`**, so "salt and pepper to taste" has no honest representation and the model presumably invents one. This is a pre-existing wart that URL import will hit constantly. *Recommendation: make `amount` `Optional[float]`* — but it touches the list-merge arithmetic at `main.py:540-557`, so it needs its own care.
 3. **Video links?** Pasting an Instagram or TikTok URL will fail with `NoSchemaFoundInWildMode`. Do we detect those hosts and show "video import isn't supported yet", or let it fall through to the generic error? A clear message is cheap and this *will* happen.
 4. **Rate limiting.** This endpoint makes the server fetch arbitrary URLs. Even with the SSRF guard it's an abuse vector for traffic amplification. Needs the #50 P0 rate-limiting work — arguably a hard dependency rather than a nice-to-have.
+
+---
+
+## Appendix A — SSRF in detail
+
+### What the vulnerability is
+
+Server-Side Request Forgery: the client supplies a URL and the **server** makes the request. The attacker doesn't get to reach the destination themselves — they borrow our server's network position to do it.
+
+That matters because our server sits *inside* a trust boundary the attacker is outside of. It can reach the container's loopback interface, Railway's private network, and whatever the platform exposes on link-local addresses. A browser on the open internet can reach none of those.
+
+`POST /api/recipes/import-from-url/` is close to the worst-case shape:
+
+- **The attacker fully controls the destination** — that's the entire feature
+- **The response comes back to them.** We parse the fetched page and return the result. That makes it a **full-read** SSRF rather than a blind one. Blind SSRF leaks timing; full-read leaks content.
+- **It is currently unauthenticated** (see #50 P0). Anyone on the internet, no account needed.
+
+### What an attacker actually gets
+
+**1. Cloud metadata services.** The classic target is the link-local endpoint `169.254.169.254`. On AWS this serves IAM role credentials at `/latest/meta-data/iam/security-credentials/`, which is precisely how the 2019 Capital One breach happened — an SSRF used to lift EC2 role credentials, ~100M records.
+
+Railway runs on GCP, where the metadata service requires a `Metadata-Flavor: Google` header and returns 403 without it. That is real defence-in-depth, and it means a naive `GET http://169.254.169.254/` probably fails today. **Do not rely on it.** It's a property of the current platform, not of our code; it evaporates if we ever add header passthrough, move providers, or run anything locally. I have not verified exactly what Railway's runtime exposes to containers — treat that as unknown rather than safe.
+
+**2. Railway's private network.** Services in a Railway project reach each other over an internal DNS namespace on IPv6. `railway.json` defines two services, so `http://omlete-client.railway.internal:3000/` is reachable from the API container today. The exposure grows with every internal service added later — a Redis, an admin surface, a database.
+
+**3. Loopback.** `http://127.0.0.1:8000/` is our own API. Two consequences: it bypasses any IP-based rate limiting (requests appear to originate locally), and any future admin endpoint bound to localhost-only becomes internet-reachable.
+
+**4. Internal reconnaissance.** Even where the body isn't readable, response timings and error types distinguish "connection refused" from "connected but wrong protocol" — enough to map what's listening.
+
+**5. Request laundering.** Ignoring internal access entirely: an unauthenticated fetch-any-URL endpoint lets someone use our server as an anonymising relay. The target sees Railway's IP, not theirs.
+
+### Why the obvious mitigations fail
+
+This is the part worth internalising. Each of these looks like a fix and isn't.
+
+**"Block hostnames containing localhost or 127.0.0.1."** Defeated by encoding: `http://0177.0.0.1/` (octal), `http://2130706433/` (decimal), `http://127.1/` (shorthand), `http://[::ffff:127.0.0.1]/` (IPv4-mapped IPv6). Also defeated by public DNS names that resolve inward — `localtest.me` and friends resolve to `127.0.0.1`. String matching on the hostname is the wrong layer. **Resolve first, then check the resulting IP.**
+
+**"Check the IP before fetching."** Necessary but not sufficient on its own, because of redirects. We validate `https://evil.example/x`, it's a genuine public address, we fetch it — and it returns `302 Location: http://169.254.169.254/`. `httpx` follows redirects when asked to, and the second request never passes through our check. **This is the mitigation people most often miss.** Either disable automatic redirects and walk the chain manually, re-validating each hop, or don't allow redirects at all.
+
+**"Check the IP, then fetch."** There's still a time-of-check/time-of-use gap. We resolve the name and validate; `httpx` then resolves it *again* when it opens the connection. An attacker serving a TTL-0 record can return a public address to the first lookup and a private one to the second — DNS rebinding.
+
+Closing this properly means connecting to the already-validated IP rather than re-resolving, which is fiddly with TLS (SNI and `Host` have to be set explicitly, and it breaks against some CDNs). **My recommendation: accept this as a known residual risk for now.** It requires an attacker to control a DNS server *and* win a timing race, which is a long way beyond the realistic threat model for this app. Document it, don't over-engineer it. Revisit if the app ever holds credentials worth stealing.
+
+**"Only allow http and https."** Do it — it's free, and it kills `file:///etc/passwd`, `gopher://` and `dict://`. But note `httpx` is HTTP-only anyway, so this is belt-and-braces rather than the main control.
+
+**"Only check IPv4 private ranges."** Railway's private networking is IPv6. Missing `::1`, unique-local `fc00::/7`, link-local `fe80::/10` and IPv4-mapped forms leaves the most relevant path open.
+
+### Reference implementation
+
+```python
+import ipaddress, socket
+from urllib.parse import urlparse
+import httpx
+
+MAX_BYTES = 2 * 1024 * 1024
+MAX_REDIRECTS = 5
+TIMEOUT = httpx.Timeout(10.0, connect=5.0)
+UA = "OmleteBot/1.0 (+https://omlete.app; recipe import)"
+
+
+class BlockedURL(Exception):
+    """The URL resolves somewhere we refuse to fetch."""
+
+
+def _assert_public(host: str) -> None:
+    """Resolve `host` and reject if ANY returned address is non-public."""
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror as exc:
+        raise BlockedURL(f"cannot resolve {host}") from exc
+
+    for info in infos:
+        ip = ipaddress.ip_address(info[4][0])
+        # IPv4-mapped IPv6 (::ffff:127.0.0.1) must be unwrapped before checking
+        if getattr(ip, "ipv4_mapped", None):
+            ip = ip.ipv4_mapped
+        if (
+            ip.is_private or ip.is_loopback or ip.is_link_local
+            or ip.is_reserved or ip.is_multicast or ip.is_unspecified
+        ):
+            raise BlockedURL(f"{host} resolves to non-public address {ip}")
+
+
+def _validate(url: str) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise BlockedURL(f"unsupported scheme: {parsed.scheme!r}")
+    if not parsed.hostname:
+        raise BlockedURL("missing hostname")
+    _assert_public(parsed.hostname)
+
+
+async def fetch_page(url: str) -> str:
+    """Fetch a page, re-validating on every redirect hop."""
+    async with httpx.AsyncClient(
+        follow_redirects=False,          # we walk the chain ourselves
+        timeout=TIMEOUT,
+        headers={"User-Agent": UA},
+    ) as client:
+        for _ in range(MAX_REDIRECTS):
+            _validate(url)               # <-- runs again for each hop
+            async with client.stream("GET", url) as response:
+                if response.is_redirect:
+                    location = response.headers.get("location")
+                    if not location:
+                        raise BlockedURL("redirect without Location")
+                    url = str(response.url.join(location))
+                    continue
+
+                response.raise_for_status()
+
+                # Enforce the size cap while streaming, not after
+                chunks, total = [], 0
+                async for chunk in response.aiter_bytes():
+                    total += len(chunk)
+                    if total > MAX_BYTES:
+                        raise BlockedURL("response too large")
+                    chunks.append(chunk)
+                return b"".join(chunks).decode(
+                    response.encoding or "utf-8", errors="replace"
+                )
+
+        raise BlockedURL("too many redirects")
+```
+
+Three details that carry most of the weight:
+
+1. `_validate()` is inside the redirect loop, so every hop is checked — not just the URL the user typed.
+2. `_assert_public()` iterates **all** `getaddrinfo` results. A hostname with both an A and an AAAA record has to pass on both.
+3. The size cap is enforced **while streaming**. Checking `Content-Length` afterwards is useless against a server that lies or omits it.
+
+### Test cases
+
+These belong in `server/tests/test_recipe_import.py` and need no network:
+
+| Input | Expected |
+|---|---|
+| `http://127.0.0.1:8000/` | `BlockedURL` |
+| `http://169.254.169.254/latest/meta-data/` | `BlockedURL` |
+| `http://[::1]/` | `BlockedURL` |
+| `http://0177.0.0.1/` and `http://2130706433/` | `BlockedURL` |
+| `http://[::ffff:127.0.0.1]/` | `BlockedURL` (exercises the `ipv4_mapped` unwrap) |
+| `http://omlete-client.railway.internal/` | `BlockedURL` |
+| `file:///etc/passwd` | `BlockedURL` (scheme) |
+| Public host → `302` → `http://169.254.169.254/` | `BlockedURL` **on the second hop** |
+| 6-hop redirect chain | `BlockedURL` (too many redirects) |
+| Response streaming past 2 MB | `BlockedURL` (too large) |
+| Ordinary public recipe URL | succeeds |
+
+Mock `socket.getaddrinfo` to make the resolution cases deterministic.
+
+### Residual risks, accepted knowingly
+
+- **DNS rebinding**, as discussed above — needs attacker-controlled DNS plus a race win.
+- **Traffic amplification** — mitigated by the #50 P0 rate limiting, not by this guard. Treat that rate limiting as a hard dependency of shipping this endpoint, not a follow-up.

--- a/docs/PRD_URL_IMPORT.md
+++ b/docs/PRD_URL_IMPORT.md
@@ -36,7 +36,9 @@ All of the below was tested directly against `recipe-scrapers` 15.11.0.
 
 ### Installation
 
-Installs cleanly in a venv with current setuptools; **583 scrapers** available. The `jstyleson` wheel failure seen earlier is a Debian-patched-setuptools artifact (`AttributeError: install_layout`) specific to the sandbox's system Python — **not** a real packaging problem. Still worth confirming on Nixpacks before merge.
+Installs cleanly in a venv with current setuptools; **583 scrapers** available. The `jstyleson` wheel failure seen earlier is a Debian-patched-setuptools artifact (`AttributeError: install_layout`) specific to the sandbox's system Python — **not** a real packaging problem.
+
+**Resolved during implementation:** `recipe-scrapers==15.11.0` installs alongside the full existing `requirements.txt` with `pip check` reporting no broken requirements. It adds ~15 transitive packages (`lxml`, `rdflib`, `pyrdfa3`, `extruct`, `html5lib`, `beautifulsoup4`, `isodate` and friends), which is a meaningful bump to image size and build time but no version conflict. Still worth watching the first Nixpacks build for `lxml` wheel availability.
 
 ### UK site coverage (confirmed present in `SCRAPERS`)
 
@@ -70,10 +72,12 @@ Tested against a realistic schema.org JSON-LD payload:
 
 | Condition | Exception | Our response |
 |---|---|---|
-| Unsupported host, `wild_mode=False` | `WebsiteNotImplementedError` | n/a — we always use `wild_mode=True` |
+| Unsupported host, `supported_only=True` | `WebsiteNotImplementedError` | n/a — we always pass `supported_only=False` |
 | No structured data anywhere | `NoSchemaFoundInWildMode` | → Claude fallback on page text |
 
-`wild_mode=True` is a strict superset: it uses the dedicated scraper when the host is supported and falls back to generic schema.org parsing when it isn't. **Always pass `wild_mode=True`.**
+⚠️ **`wild_mode` is deprecated in 15.11.0** — it emits a `DeprecationWarning` and may be removed. Use **`supported_only=False`**, which is the documented replacement.
+
+Verified equivalent: with `supported_only=False`, a supported host still resolves to its dedicated scraper (confirmed `BBCGoodFood` is returned for a bbcgoodfood.com URL), and unsupported hosts fall back to generic schema.org parsing. Exceptions raised are unchanged. It is a strict superset — **always pass `supported_only=False`**.
 
 ---
 
@@ -123,7 +127,7 @@ Expected latency ~5-8s total, versus 20-60s for the current generate flow. No st
 
 ```python
 async def fetch_page(url: str) -> str        # SSRF-guarded async fetch
-def scrape(html: str, url: str) -> ScrapedRecipe | None   # wild_mode=True
+def scrape(html: str, url: str) -> ScrapedRecipe | None   # supported_only=False
 ```
 
 **SSRF guard — required, not optional.** This endpoint takes a user-supplied URL and makes the server fetch it, then returns the parsed result to the caller. That is a textbook full-read SSRF primitive. See [Appendix A](#appendix-a--ssrf-in-detail) for the full threat model, why the obvious mitigations fail, and a reference implementation.
@@ -219,14 +223,14 @@ Index `source_url` and return 409 with the existing recipe id on re-import. Requ
 
 ## Implementation plan
 
-### Step 1 — Dependency + scraper module
+### Step 1 — Dependency + scraper module ✅ done
 - Add `recipe-scrapers` to `server/requirements.txt`
 - **Verify it builds on Nixpacks** before going further (the sandbox failure was environmental, but confirm)
 - Create `server/recipe_import.py`: `fetch_page()` with the full SSRF guard, `scrape()` wrapping `scrape_html(..., wild_mode=True)`
 - Normalise `yields()` → `Optional[int]` with a range sanity-check
 - Return a `ScrapedRecipe` dataclass
 
-### Step 2 — Tests for step 1 (before wiring anything up)
+### Step 2 — Tests for step 1 (before wiring anything up) ✅ done
 - `server/tests/test_recipe_import.py` with **saved HTML fixtures** — no network in tests
 - Fixtures: a JSON-LD page, a page with `ingredient_groups`, a no-structured-data page, a `"serves 4-6"` yields case
 - SSRF guard tests: `127.0.0.1`, `169.254.169.254`, `10.x`, `file://`, a redirect from a public host to a private one

--- a/docs/PRD_URL_IMPORT.md
+++ b/docs/PRD_URL_IMPORT.md
@@ -1,0 +1,286 @@
+# PRD: Import recipe from a web link
+
+_Child of #50. Verified against `recipe-scrapers` 15.11.0._
+
+---
+
+## Problem
+
+Omlete has two ways to get a recipe in: type your ingredients, or photograph a cookbook. Both are high-effort and low-frequency. **Pasting a link is how people actually acquire recipes**, and every competitor — Paprika, AnyList, Mela, Mealie, Tandoor, and the entire AI-native cohort — supports it.
+
+The UK case is especially strong. BBC Good Food is the [#1 cooking site in the UK](https://www.similarweb.com/top-websites/united-kingdom/food-and-drink/cooking-and-recipes/) at ~30.7M monthly visits, ahead of RecipeTin Eats, Allrecipes, HelloFresh and Jamie Oliver. UK recipes live on the open web, not in an app.
+
+## Solution
+
+A third tab on `/create` — **From link** — that takes a URL and produces a saved recipe.
+
+The important architectural point: **this is a two-stage pipeline, not one.**
+
+```
+URL ──▶ Stage 1: SCRAPE (free, ~1s, zero tokens)
+        └─ title, instructions[], image, prep/cook/total time,
+           yields, description, cuisine, category, source_url
+        └─ ingredients as FREE-TEXT STRINGS  ──▶ Stage 2: STRUCTURE (Haiku)
+                                                  └─ name / amount / unit / category
+                                                  └─ find_similar_ingredients
+                                                  └─ ──▶ _save_recipe()
+```
+
+Stage 1 gets us most of a recipe for nothing. Stage 2 is the only part that needs a model — and it's a *parsing* task, not a generation task, so it can run on Haiku and can't hallucinate the recipe itself. The instructions come through verbatim from the source.
+
+That makes this **both cheaper and more accurate than the existing image-extraction path**, which pays Opus prices to invent structure from pixels.
+
+## Verified findings
+
+All of the below was tested directly against `recipe-scrapers` 15.11.0.
+
+### Installation
+
+Installs cleanly in a venv with current setuptools; **583 scrapers** available. The `jstyleson` wheel failure seen earlier is a Debian-patched-setuptools artifact (`AttributeError: install_layout`) specific to the sandbox's system Python — **not** a real packaging problem. Still worth confirming on Nixpacks before merge.
+
+### UK site coverage (confirmed present in `SCRAPERS`)
+
+`bbcgoodfood.com` · `jamieoliver.com` · `greatbritishchefs.com` · `waitrose.com` · `realfood.tesco.com` · `mob.co.uk` · `mobkitchen.co.uk` · `gousto.co.uk` · `thehappyfoodie.co.uk` · `schoolofwok.co.uk` · `books.ottolenghi.co.uk` · `tofoo.co.uk`
+
+Not covered by a dedicated scraper: `bbc.co.uk/food`, `olivemagazine.com`, `deliciousmagazine.co.uk`, `nigella.com`, `riverford.co.uk` — these should still work through `wild_mode` if they publish JSON-LD.
+
+### What the scraper returns
+
+Tested against a realistic schema.org JSON-LD payload:
+
+| Field | Type returned | Notes |
+|---|---|---|
+| `title()` | `str` | |
+| `total_time()` / `prep_time()` / `cook_time()` | **`int`, minutes** | ISO 8601 durations already parsed for us |
+| `yields()` | `str` — `'6 servings'` | ⚠️ see gotcha below |
+| `image()` | `str` URL | |
+| `ingredients()` | **`list[str]` — free text** | ⚠️ the core constraint |
+| `ingredient_groups()` | `[IngredientGroup(ingredients=[...], purpose=None)]` | `purpose` carries "For the sauce:" headings |
+| `instructions_list()` | `list[str]` | |
+| `nutrients()` | `dict[str, str]` — `{'calories': '636 calories'}` | strings, need parsing |
+| `ratings()` | `float` — `4.7` | the *site's* crowd rating, not the user's |
+| `author()` / `category()` / `cuisine()` / `description()` | `str` | |
+| `to_json()` | `dict` of everything above | |
+
+**⚠️ Gotcha:** given `recipeYield: "serves 4-6"`, `yields()` returned `'6 servings'` — it takes the **upper bound** of a range. Best-effort normalisation; sanity-check the parsed integer rather than trusting it.
+
+**⚠️ The core constraint:** ingredients arrive as `'2 onions, finely chopped'`, not `{name, amount, unit}`. `recipe-scrapers` ships **no** ingredient parser (only internal `_grouping_utils` / `_utils`). Stage 2 is mandatory.
+
+### Failure modes (clean and distinguishable)
+
+| Condition | Exception | Our response |
+|---|---|---|
+| Unsupported host, `wild_mode=False` | `WebsiteNotImplementedError` | n/a — we always use `wild_mode=True` |
+| No structured data anywhere | `NoSchemaFoundInWildMode` | → Claude fallback on page text |
+
+`wild_mode=True` is a strict superset: it uses the dedicated scraper when the host is supported and falls back to generic schema.org parsing when it isn't. **Always pass `wild_mode=True`.**
+
+---
+
+## UX
+
+### The Create page
+
+Tabs become: **From link** · Generate · Extract from Images — with *From link* as the default (it will be the most-used path; today `extract` is the default at `create.tsx:16`).
+
+```
+┌──────────────────────────────────────────────┐
+│  [ From link ]  Generate   Extract from Images│
+├──────────────────────────────────────────────┤
+│  Paste a recipe link                          │
+│  ┌────────────────────────────────┐ ┌──────┐ │
+│  │ https://bbcgoodfood.com/...    │ │Import│ │
+│  └────────────────────────────────┘ └──────┘ │
+│                                               │
+│  Works with BBC Good Food, Jamie Oliver,      │
+│  Tesco Real Food, Waitrose, Mob and 580 more. │
+└──────────────────────────────────────────────┘
+```
+
+States: idle → `Reading the page…` (stage 1) → `Sorting the ingredients…` (stage 2) → recipe card + "View recipe" / "Add to list". Errors surface inline with the reason and a "try extracting from a photo instead" escape hatch.
+
+Expected latency ~5-8s total, versus 20-60s for the current generate flow. No streaming needed.
+
+### PWA share target
+
+`manifest.webmanifest` already exists. Adding a `share_target` lets Android users share a URL straight from Chrome, Instagram or TikTok into Omlete — which is exactly the mechanic the AI-native cohort competes on.
+
+```json
+"share_target": {
+  "action": "/create",
+  "method": "GET",
+  "params": { "title": "title", "text": "text", "url": "url" }
+}
+```
+
+`/create` reads `?url=` on mount and pre-fills the field. Cheap, and it's the difference between a feature people try once and one they use constantly.
+
+---
+
+## Technical design
+
+### New module: `server/recipe_import.py`
+
+```python
+async def fetch_page(url: str) -> str        # SSRF-guarded async fetch
+def scrape(html: str, url: str) -> ScrapedRecipe | None   # wild_mode=True
+```
+
+**SSRF guard — required, not optional.** This endpoint takes a user-supplied URL and makes the server fetch it. Without a guard it's a hole straight into the internal network. Must:
+
+- Allow only `http`/`https` schemes
+- Resolve the hostname and **reject private/reserved ranges**: `127.0.0.0/8`, `10/8`, `172.16/12`, `192.168/16`, `169.254/16` (cloud metadata — `169.254.169.254` is the one that matters), `::1`, unique-local v6
+- Re-check after **every redirect**, cap redirects at ~5
+- Cap response size (~2 MB) and timeout (~10s)
+- Send a real User-Agent; many sites 403 a default `python-httpx`
+
+`httpx==0.28.1` is already in `requirements.txt`, so use `httpx.AsyncClient` rather than `scrape_me()` — the latter fetches synchronously and would block the event loop.
+
+### New module: `server/ingredient_structurer.py`
+
+Takes `list[str]` of raw ingredient lines plus the category list; returns `list[IngredientModelResponse]`.
+
+Reuses the existing `tool_runner` + `find_similar_ingredients` + `output_config` pattern from `main.py:124-133`, but on **`claude-haiku-4-5-20251001`**.
+
+Prompt requirements:
+- Split each line into `name`, `amount`, `unit`
+- **Strip preparation from the name**: `"2 onions, finely chopped"` → name `onions`, note `finely chopped`
+- Call `find_similar_ingredients` to canonicalise against our vocabulary
+- Assign a category from the user's list for new ingredients
+- Preserve group headings from `ingredient_groups()` where present
+
+### Endpoint: `POST /api/recipes/import-from-url/`
+
+```
+Request:  { "url": "https://www.bbcgoodfood.com/recipes/classic-lasagne" }
+200 →     RecipeDocument (same shape as the existing extract endpoint)
+400 →     malformed URL, unsupported scheme, or blocked host
+404 →     page fetched but no recipe found (after Claude fallback)
+502 →     source site unreachable / timed out
+409 →     already imported (returns the existing recipe id)
+```
+
+Flow:
+
+1. Validate + SSRF-guard the URL
+2. Fetch HTML
+3. `scrape_html(html, org_url=url, wild_mode=True)`
+4. On `NoSchemaFoundInWildMode` → strip the page to text and run the **existing** Opus generate path as a fallback
+5. Structure the ingredient strings (Haiku)
+6. Map to `RecipeDocument` and `_save_recipe()`
+
+### Model changes
+
+`server/lib/types.py` — extend `Recipe`:
+
+```python
+class Recipe(BaseModel):
+    title: str
+    instructions: list[str]
+    servings: Optional[int] = None
+    prep_minutes: Optional[int] = None
+    cook_minutes: Optional[int] = None
+    total_minutes: Optional[int] = None
+    image_url: Optional[str] = None
+    source_url: Optional[str] = None
+    source_name: Optional[str] = None      # e.g. "BBC Good Food"
+    description: Optional[str] = None
+    cuisine: Optional[str] = None
+```
+
+All optional, so existing documents deserialise unchanged — **no migration needed**.
+
+`IngredientRecipe` gains `note: Optional[str]` for the stripped prep text.
+
+### Deduplication
+
+Index `source_url` and return 409 with the existing recipe id on re-import. Requires the index work from #50's P0 anyway.
+
+---
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Scrape library | `recipe-scrapers`, `wild_mode=True` always | 583 dedicated scrapers + generic schema.org fallback in one call |
+| Fetching | `httpx.AsyncClient`, not `scrape_me()` | `scrape_me()` blocks the event loop |
+| Stage 2 model | Haiku 4.5 | Parsing, not generation. ~95% cheaper than Opus |
+| No-structured-data fallback | Existing Opus generate path on page text | Reuses code; rare enough that cost doesn't matter |
+| Import the site's rating? | **No** | It's the crowd's rating, not the user's. Our `rating` field means "did *I* like it" |
+| Import nutrition? | **No, not yet** | Returns unparsed strings; out of scope per #50 |
+| Hero image | Store the URL, don't re-host | Cheap. Hotlinks can rot — re-hosting is a later improvement |
+| Save directly or preview first? | **Preview, then save** | See open question 1 — recommended but costs an extra step |
+| Default Create tab | From link | Will be the most-used path |
+| robots.txt | Ignore, but always store `source_url` | User is importing a page they're already viewing; attribution is the right etiquette |
+
+---
+
+## Implementation plan
+
+### Step 1 — Dependency + scraper module
+- Add `recipe-scrapers` to `server/requirements.txt`
+- **Verify it builds on Nixpacks** before going further (the sandbox failure was environmental, but confirm)
+- Create `server/recipe_import.py`: `fetch_page()` with the full SSRF guard, `scrape()` wrapping `scrape_html(..., wild_mode=True)`
+- Normalise `yields()` → `Optional[int]` with a range sanity-check
+- Return a `ScrapedRecipe` dataclass
+
+### Step 2 — Tests for step 1 (before wiring anything up)
+- `server/tests/test_recipe_import.py` with **saved HTML fixtures** — no network in tests
+- Fixtures: a JSON-LD page, a page with `ingredient_groups`, a no-structured-data page, a `"serves 4-6"` yields case
+- SSRF guard tests: `127.0.0.1`, `169.254.169.254`, `10.x`, `file://`, a redirect from a public host to a private one
+- This is the highest-value test surface in the feature — it's pure functions over fixed input
+
+### Step 3 — Ingredient structurer
+- `server/ingredient_structurer.py` on Haiku, reusing the `tool_runner` + `find_similar_ingredients` pattern
+- Unit tests with a mocked Anthropic client, mirroring `tests/test_ingredient_service.py`
+- **Risk:** confirm Haiku 4.5 handles structured output + tool use reliably. If not, fall back to Sonnet — still far cheaper than Opus
+
+### Step 4 — Model changes
+- Extend `Recipe` and `IngredientRecipe` in `server/lib/types.py`
+- No migration needed (all optional), but confirm existing docs still deserialise
+- Add the `source_url` index
+
+### Step 5 — Endpoint
+- `POST /api/recipes/import-from-url/` in `server/main.py`
+- Wire the fallback chain and the error taxonomy above
+- Dedup check on `source_url`
+
+### Step 6 — Frontend
+- New `LinkTab` in `client/src/routes/create.tsx`, made the default
+- Two-phase progress copy ("Reading the page…" → "Sorting the ingredients…")
+- **Real error handling** — this is the first feature that genuinely needs it, and it's a #50 P0 item
+- Surface `image_url`, times and servings on `RecipeCard` and the recipe detail page
+
+### Step 7 — Share target
+- `share_target` in `manifest.webmanifest`
+- `/create` reads `?url=` on mount and pre-fills
+- Test on Android Chrome — iOS does not support Web Share Target
+
+### Step 8 — Docs
+- Update `README.md` / `CLAUDE.md` (both currently describe endpoints that don't exist)
+
+**Suggested sequencing:** steps 1-2 are self-contained and testable with zero network and zero tokens — worth doing first and merging on their own. Steps 3-5 are the backend spine. Steps 6-7 are frontend. Step 4 (model changes) unblocks other #50 work, so pulling it earlier is reasonable.
+
+---
+
+## Verification
+
+1. A BBC Good Food URL produces a complete recipe — title, steps, image, times, servings — with structured ingredients and **zero Opus calls**
+2. Ingredients are canonicalised: importing a recipe with "spring onions" matches an existing "scallions" entry rather than creating a duplicate
+3. `"2 onions, finely chopped"` yields name `onions`, amount `2`, with `finely chopped` in the note
+4. A recipe with "For the sauce:" headings preserves the grouping
+5. An unsupported site that publishes JSON-LD still imports via `wild_mode`
+6. A blog with no structured data falls back to Claude and still produces a recipe
+7. Re-importing the same URL returns 409 with the existing recipe rather than a duplicate
+8. `http://169.254.169.254/latest/meta-data/` is rejected, as is a public URL that 302s to a private address
+9. A 50 MB response is truncated, not swallowed
+10. Sharing a link from Chrome on Android opens Omlete with the URL pre-filled
+
+---
+
+## Open questions
+
+1. **Preview before save, or save immediately?** The existing extract flow saves immediately. Preview is better UX — Paprika does it, and it stops bad imports polluting the library — but it's an extra screen and an extra state. *Recommendation: preview.* Import quality varies too much across sites to save blind.
+2. **What do we do about `amount` on unquantified ingredients?** `IngredientRecipe.amount` is currently a **required `float`**, so "salt and pepper to taste" has no honest representation and the model presumably invents one. This is a pre-existing wart that URL import will hit constantly. *Recommendation: make `amount` `Optional[float]`* — but it touches the list-merge arithmetic at `main.py:540-557`, so it needs its own care.
+3. **Video links?** Pasting an Instagram or TikTok URL will fail with `NoSchemaFoundInWildMode`. Do we detect those hosts and show "video import isn't supported yet", or let it fall through to the generic error? A clear message is cheap and this *will* happen.
+4. **Rate limiting.** This endpoint makes the server fetch arbitrary URLs. Even with the SSRF guard it's an abuse vector for traffic amplification. Needs the #50 P0 rate-limiting work — arguably a hard dependency rather than a nice-to-have.

--- a/docs/WHISK_ANALYSIS.md
+++ b/docs/WHISK_ANALYSIS.md
@@ -1,0 +1,230 @@
+# Whisk / Samsung Food — Deep Dive & Differentiation Strategy
+
+_July 2026. Companion to `GAP_ANALYSIS.md`._
+
+---
+
+## 1. Why this competitor matters more than the others
+
+Whisk is not just another recipe app. It is **the company that already tried to build what Omlete is building**, took it further than anyone, and then got absorbed into a hardware business.
+
+- Founded **2012 by Nick Holzherr** in **Birmingham, UK**, launched January 2013 after he pitched it to Lord Sugar as a 2012 *Apprentice* finalist.
+- Raised **$39.1M across 5 rounds**.
+- Built the **Food Genome** — the core technology, described below.
+- Pre-acquisition it powered **500M+ recipe interactions per month** across publishers, brands and retailers.
+- **Acquired by Samsung NEXT in March 2019.** Holzherr went on to lead ~120 people building the Samsung Food experience.
+- Rebranded **Samsung Food** in 2023; global launch across **104 countries, 8 languages**.
+
+So the strategic read is: *the thesis was right, it was validated with real money and real scale, and the company that proved it is now optimising for selling refrigerators.* That's both the threat and the opening.
+
+---
+
+## 2. The Food Genome — what it actually is
+
+This is the piece worth understanding properly, because it's the closest thing in the market to what `ingredient_service.py` is reaching for.
+
+Whisk's Food Genome is an **AI/NLP-built food ontology** that maps:
+
+| Axis | What it encodes |
+|---|---|
+| **Identity** | Canonical ingredients and their relationships (synonyms, hypernyms, varieties) |
+| **Products** | Mapping from a recipe ingredient string → an actual purchasable SKU at a specific retailer |
+| **Nutrition** | Per-ingredient nutritional data, aggregated to recipe and per-serving |
+| **Perishability** | How long things last — feeds expiry and waste features |
+| **Flavour** | Ingredient affinity, used for substitutions and recommendations |
+| **Availability** | What's actually in stock, seasonally and per-store |
+
+It's described as "an always evolving food ontology that enables machine learning algorithms to map the relationships between ingredients, products, and recipes."
+
+### The critical observation for Omlete
+
+**Whisk spent roughly seven years and $39M building the identity axis. In 2026 you get most of it for the price of an embedding call.**
+
+`ingredient_service.py` — sixty lines of Voyage-4 embeddings plus a Mongo `$vectorSearch` — does the ingredient-identity job that was Whisk's original moat. That moat has been commoditised by foundation models, and Omlete is already standing on the other side of it.
+
+**But identity is one axis of six.** The other five — products, nutrition, perishability, flavour, availability — are *data* problems, not model problems. No amount of Claude gets you Tesco's SKU catalogue or live stock levels. Those required partnerships, and that's where the real defensibility sat.
+
+The honest conclusion: **don't try to rebuild the Food Genome.** Pick the axes where a model substitutes for data (identity, flavour, substitution) and skip the ones that need contracts (products, availability), or rent them.
+
+---
+
+## 3. Full feature inventory: Samsung Food today
+
+### Recipe acquisition
+- URL import from any site (the original Whisk capability, built on their recipe parser)
+- 160,000–240,000 recipes in the built-in library
+- Browser extension for one-click saving — **though multiple reviews report it has been broken since the 2023 rebrand**
+- Recipe format standardisation and auto-organisation
+
+### AI features
+- **Food AI recipe transformation** — take a saved recipe and have the model convert it to vegan/vegetarian, make it more nutritionally balanced, or rewrite it around ingredients you already have
+- **Vision AI** — photograph a meal, get calorie and nutrition estimates. **Galaxy devices only.**
+- AI-personalised weekly meal plans (Food+ tier)
+
+### Planning and shopping
+- Meal planner calendar
+- Auto-generated shopping lists from recipes and plans
+- **Shoppable lists → checkout at real retailers.** 29 integrated online grocers globally. UK partners include **Tesco, Asda, Sainsbury's, Waitrose and Ocado** (Sainsbury's added Jan 2021); US includes Kroger.
+- Ingredient → product (SKU) matching, with prices
+
+### Health
+- Auto-derived nutrition per recipe and per serving
+- **Samsung Health integration** — meal recommendations driven by BMI, body composition and calorie consumption
+- Per-recipe "Health Score"
+
+### Social and collaboration
+- **Communities**, public and private, organised around themes ("vegan diet", "beginner friendly")
+- Follow other users and food creators; creator profiles with Instagram/YouTube/TikTok links
+- **Share recipes, shopping lists AND the meal planner** with anyone holding an account — invite by name, email, text or social
+
+### Ecosystem
+- Family Hub smart fridge integration; send recipes to connected ovens
+- iOS, Android, Web, Galaxy
+- **B2B platform** — recipe CMS for brands and grocers. This was Whisk's actual revenue engine.
+
+### Pricing
+- Free tier, plus **Samsung Food+** at **$6.99/month or $59.99/year** (~£5.50/month UK), 7-day trial. Purchasable with Samsung Rewards points.
+
+---
+
+## 4. The gap list — what they have that Omlete doesn't
+
+Beyond the table-stakes items already in `GAP_ANALYSIS.md` (URL import, photos, search, servings, times, meal plan, pantry, cook mode, offline, auth), Whisk-specific gaps:
+
+| # | Gap | Severity | Notes |
+|---|---|:--:|---|
+| 1 | **Shoppable lists → real checkout** | 🔴 | 29 retailers. The single biggest functional gap. Business development, not engineering. |
+| 2 | **Ingredient → SKU/product matching** | 🔴 | "500g plain flour" → a real Tesco product with a price. Omlete stops at the string. |
+| 3 | **Nutrition data** | 🟠 | Auto-derived per recipe/serving. Needs a food composition database, not a model. |
+| 4 | **Recipe transformation** | 🟠 | Omlete *generates* recipes but can't *transform* an existing one. This one is cheap for you — it's a Claude call over a recipe you already hold. |
+| 5 | **Household collaboration** | 🟠 | Shared recipes + lists + meal planner. Blocked on your missing auth layer. |
+| 6 | **Social / communities** | 🟡 | Follow creators, public/private communities. Real retention driver; expensive to build; needs scale to work at all. |
+| 7 | **Meal photo → nutrition (Vision AI)** | 🟡 | Galaxy-only for them. Claude vision does this today, on any device. |
+| 8 | **Appliance integration** | ⚪ | Not realistically available to you and not worth chasing. |
+| 9 | **B2B recipe CMS** | ⚪ | Different business. Flagged only because it's where their money came from. |
+
+---
+
+## 5. Where Whisk is weak — the actual openings
+
+These are recurring themes in third-party reviews (MealThinker, Plan to Eat, UK reviewers) rather than anything Samsung publishes. Treat them as strong signals, not audited fact.
+
+### 🎯 Opening 1 — Serving-size changes don't propagate to shopping lists
+
+Reviewers report this as a persistent, unfixed bug: change the servings on a recipe and the shopping list doesn't follow.
+
+**This is precisely the problem Omlete's data model already solves.** `ItemSource` (`main.py:519-595`) tracks which recipe contributed which amount to every list item, so amounts recompute correctly on add and remove. Samsung bolted scaling on top of a merge-and-forget list; you built the provenance in from the start.
+
+You don't have servings yet — but when you add them, the plumbing to make scaling flow correctly into the list is *already written*. That's a feature you can ship correct on day one that a 120-person team has left broken for months.
+
+### 🎯 Opening 2 — No leftovers or batch-cooking model
+
+Reported clearly: cook a big batch on Sunday and the app has no way to factor it into the rest of the week.
+
+Nobody in the market handles this. And again, `ItemSource` is the right shape — it already expresses "this quantity came from that source." Extending it from *contribution* to *consumption* (a batch produces N portions; meals draw them down) is a natural evolution of code you have, not a new subsystem.
+
+This is arguably the single most differentiated feature available to you.
+
+### 🎯 Opening 3 — Pantry is paywalled and basic
+
+Samsung Food doesn't know what's in your fridge unless you pay, and reviewers describe the pantry as thin even then.
+
+There's a structural reason: **Samsung's shopping list monetises buying, and Samsung's hardware business monetises fridges.** An app that's excellent at helping you use up what you already own works against both. Omlete has no such conflict.
+
+### 🎯 Opening 4 — One grocery store per shopping list
+
+A real constraint for households that split a shop across Aldi and a Tesco top-up — which in the UK is most households.
+
+### 🎯 Opening 5 — The Health Score is actively disliked
+
+Samsung Food assigns every recipe a "Health Score" labelling food good or bad. Multiple users have called this out as "seeped in fat phobia and diet culture language."
+
+**Not scoring people's food is a free positioning win.** It costs nothing to build and directly answers a stated grievance.
+
+### 🎯 Opening 6 — Post-acquisition decay
+
+The pattern across reviews: bugs acknowledged but unfixed for months, a browser extension broken since 2023, support described as unresponsive. This is what happens when a beloved indie product becomes a feature of an appliance division — the KPI stops being "do home cooks love this" and becomes "does this sell Family Hubs."
+
+### 🎯 Opening 7 — Device bias
+
+Vision AI is Galaxy-only. Samsung Health integration presumes a Samsung phone. Collaboration requires every household member to hold a Samsung Food account.
+
+Omlete is a PWA. **Device-neutral, install-free, share-by-link** is a genuine wedge — and it's AnyList's entire business, except AnyList has no AI.
+
+---
+
+## 6. Where Omlete is already better
+
+Worth being clear-eyed about, because these are the foundations to build the strategy on.
+
+1. **Source-tracked list arithmetic.** `ItemSource` is a better data model than theirs. Verified by their own reported scaling bug.
+2. **Generate-from-ingredients as a first-class flow.** Whisk *imports* recipes; it doesn't invent them. Omlete's `/recipes/generate/` starts from what you have.
+3. **Multi-photo cookbook extraction into one recipe.** Handles a two-page spread. Most competitors treat each photo as a separate recipe.
+4. **Plan vs Shop modes.** Same data, two intents. Genuinely thoughtful and rare.
+5. **No moralising about food.**
+
+---
+
+## 7. Strategy: what Omlete should be that Samsung Food isn't
+
+**You cannot beat Samsung Food on breadth.** 120 people, $39M of accumulated food data, retailer contracts in 29 markets. Competing feature-for-feature loses.
+
+The opening is that Samsung Food is a **discovery-and-acquisition** app — *find a recipe → buy the ingredients* — because that's what monetises. Omlete's origin story is the inverse.
+
+### The positioning
+
+> **Samsung Food helps you decide what to buy. Omlete helps you use what you have.**
+
+Different emotional job: not aspiration and inspiration, but **reducing waste and killing the 6pm "what do we eat" decision**. Samsung is structurally bad at this — their pantry is paywalled and thin *because* helping you cook from an empty-ish fridge doesn't sell groceries or refrigerators.
+
+### The three-feature spine
+
+**1. Pantry with semantic matching.**
+You have the best ingredient vocabulary of anyone — embedded, canonicalised, similarity-scored. SuperCook does this with a fixed 2,000-item taxonomy; you can do it with free text and embeddings. "I have scallions" satisfies a recipe calling for spring onions. Close the loop: check an item off a shopping list → it enters the pantry → the next list omits it.
+
+**2. "What can I make?" ranked by coverage.**
+Vector-match pantry contents against the recipe library. Rank by percentage covered. Surface "you're 2 ingredients away from X." This is the app's stated premise, finally delivered — and it's the natural home for the tech you've already built.
+
+**3. Leftovers and batch cooking as first-class objects.**
+A recipe yields portions; portions get consumed across days; the meal plan and the shopping list both account for them. Nobody does this. `ItemSource` is already the right shape.
+
+### Supporting moves, in rough priority order
+
+- **Semantic + unit-aware list merging.** Immediate, visible, uses code you've written. Fixes "spring onions" and "scallions" appearing as two lines. *This should ship first — it's the cheapest demonstration of the whole thesis.*
+- **Recipe transformation** ("make this vegan", "halve it", "swap the crème fraîche for what I have"). One Claude call over a recipe you already hold. Matches a headline Samsung Food+ feature at near-zero cost.
+- **Waste-driven suggestions.** Pantry items by age, plus items that have lingered unchecked on lists, bias `suggest_meals`. A concrete reason to open the app on a Tuesday.
+- **Household sharing via link, no account required.** Needs the auth work from Phase 0, but a share-by-link PWA list beats "everyone install Samsung Food."
+- **UK-first import.** Verified: `recipe-scrapers` already covers bbcgoodfood.com, jamieoliver.com, greatbritishchefs.com, waitrose.com, realfood.tesco.com, mob.co.uk, gousto.co.uk, thehappyfoodie.co.uk and more. UK aisle ordering, UK units, UK sources.
+- **Explicitly no health scores.** State it. It's a differentiator that costs a sentence.
+
+### What to deliberately *not* build
+
+- Ingredient → SKU matching and grocery checkout. Needs retailer contracts. In the US, [Instacart's Developer Platform](https://docs.instacart.com/developer_platform_api/guide/concepts/shopping_list/) will do the product matching and hand back a hosted list URL — worth knowing, but there's no comparably easy UK equivalent. Revisit only if the app gets traction.
+- A nutrition database. Needs a food composition dataset (OpenFoodFacts is the free route Tandoor uses). Model-estimated nutrition is a liability, not a feature.
+- Social/communities. Needs scale to be anything but empty rooms.
+- Appliance integration. Not available to you.
+
+---
+
+## 8. The one-paragraph version
+
+Whisk proved the thesis, built a genuine moat in ingredient understanding, and sold to a hardware company that is now optimising it for fridge attach rate. Foundation models have since commoditised the identity half of that moat — Omlete gets it from an embedding call. The remaining half needs retailer data, which isn't winnable and shouldn't be chased. The opening is that Samsung Food is structurally committed to helping you *buy* food, which makes it structurally bad at helping you *use* food. Omlete should be the app for what's already in the fridge: pantry, coverage-ranked suggestions, leftovers as first-class objects, and shopping lists that are semantically smart because the ingredient graph was there from the beginning.
+
+---
+
+## Sources
+
+- [Samsung Next — Whisk's genome and ontology for AI Food](https://component.samsungnext.com/blog/component-whisk-food-genome-uses-ai)
+- [VentureBeat — How Whisk is using its food genome to turn recipes into smart shopping lists](https://venturebeat.com/ai/how-whisk-is-using-its-food-genome-to-turn-recipes-into-smart-shopping-lists/)
+- [Whisk Adds Sainsbury's to Partner Ecosystem — Businesswire](https://www.businesswire.com/news/home/20210126005433/en/Whisk-Adds-Sainsburys-to-Partner-Ecosystem-to-Enable-Shoppable-Recipes-Across-the-UK)
+- [Whisk adds Kroger to Partner Ecosystem — Perishable News](https://perishablenews.com/retailfoodservice/whisk-adds-the-kroger-co-to-partner-ecosystem-making-online-recipes-instantly-shoppable-at-kroger-family-of-stores/)
+- [Samsung announces global launch of Samsung Food — Samsung Newsroom UK](https://news.samsung.com/uk/samsung-announces-global-launch-of-samsung-food-an-ai-powered-personalised-food-and-recipe-service)
+- [The Story of Samsung Food with Nick Holzherr — The Spoon](https://thespoon.tech/the-story-of-samsung-food-with-nick-holzherr/)
+- [Food tech firm Whisk.com bought by Samsung — BusinessCloud](https://businesscloud.co.uk/news/food-tech-firm-whiskcom-bought-by-samsung/)
+- [Whisk — Crunchbase](https://www.crunchbase.com/organization/whisk)
+- [Samsung Food App 2026: Vision AI Features, Limits & Best Alternatives — MealThinker](https://mealthinker.com/blog/samsung-food-alternative)
+- [Samsung Food Review: Pros and Cons — Plan to Eat](https://www.plantoeat.com/blog/2026/01/samsung-food-review-pros-and-cons/)
+- [Whisk/Samsung Food App Review UK — Home Cooks](https://home-cooks.co.uk/pages/review-whisk)
+- [Samsung Food Communities FAQ](https://support.samsungfood.com/hc/en-us/articles/18365378908820-Communities-FAQs)
+- [Sharing & Collaboration on Samsung Food](https://support.samsungfood.com/hc/en-us/articles/18689681101716-Sharing-Collaboration-on-Samsung-Food)
+- [Food Plus — Samsung Food](https://samsungfood.com/food-plus/)

--- a/server/recipe_import.py
+++ b/server/recipe_import.py
@@ -1,0 +1,297 @@
+"""Fetch and parse recipes from public web pages.
+
+This is stage 1 of the URL import pipeline described in docs/PRD_URL_IMPORT.md:
+fetch a page and pull out whatever structured recipe data it publishes. The
+ingredients come back as free text (``"2 onions, finely chopped"``) because
+recipe-scrapers does not decompose them — turning those lines into structured
+IngredientRecipe objects is stage 2 and lives elsewhere.
+
+The fetch is deliberately paranoid. The URL comes from the caller and we make
+the request, so an unguarded fetch would let anyone reach our loopback
+interface, Railway's private network, or a cloud metadata endpoint. See
+Appendix A of the PRD for the full threat model.
+"""
+
+import asyncio
+import ipaddress
+import re
+import socket
+from dataclasses import dataclass, field
+from typing import Callable, Optional, TypeVar
+from urllib.parse import urlparse
+
+import httpx
+from recipe_scrapers import scrape_html
+from recipe_scrapers._exceptions import (
+    NoSchemaFoundInWildMode,
+    WebsiteNotImplementedError,
+)
+
+_MAX_BYTES = 2 * 1024 * 1024
+_MAX_REDIRECTS = 5
+_TIMEOUT = httpx.Timeout(10.0, connect=5.0)
+# Plenty of recipe sites reject the default httpx agent outright.
+_USER_AGENT = "OmleteBot/1.0 (+https://omlete.app; recipe import)"
+
+# Yields above this are almost certainly a misparse (a stray year, a weight),
+# so we drop them rather than store nonsense.
+_MAX_PLAUSIBLE_SERVINGS = 100
+
+
+class BlockedURL(Exception):
+    """The URL is malformed, or resolves somewhere we refuse to fetch."""
+
+
+class FetchFailed(Exception):
+    """The page could not be retrieved from the origin."""
+
+
+@dataclass
+class IngredientGroup:
+    """A run of ingredients under an optional heading ("For the sauce:")."""
+
+    purpose: Optional[str]
+    ingredients: list[str]
+
+
+@dataclass
+class ScrapedRecipe:
+    """Stage 1 output. `ingredients` is free text pending stage 2."""
+
+    title: str
+    instructions: list[str]
+    ingredients: list[str]
+    source_url: str
+    ingredient_groups: list[IngredientGroup] = field(default_factory=list)
+    servings: Optional[int] = None
+    prep_minutes: Optional[int] = None
+    cook_minutes: Optional[int] = None
+    total_minutes: Optional[int] = None
+    image_url: Optional[str] = None
+    source_name: Optional[str] = None
+    description: Optional[str] = None
+    cuisine: Optional[str] = None
+
+
+# --- SSRF guard ---
+
+
+def _is_forbidden(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """True for anything that isn't a routable public address.
+
+    IPv4-mapped IPv6 (``::ffff:127.0.0.1``) is unwrapped first: IPv6Address
+    reports is_loopback only for ``::1``, so the mapped form would otherwise
+    slip straight through.
+    """
+    mapped = getattr(ip, "ipv4_mapped", None)
+    if mapped is not None:
+        ip = mapped
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
+
+
+async def _resolve(host: str) -> list[str]:
+    """Resolve a hostname to every address it answers with."""
+    loop = asyncio.get_running_loop()
+    try:
+        infos = await loop.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as exc:
+        raise BlockedURL(f"could not resolve {host!r}") from exc
+    return [info[4][0] for info in infos]
+
+
+async def _assert_public(host: str) -> None:
+    """Reject the host if *any* address it resolves to is non-public.
+
+    A name with both an A and an AAAA record has to pass on both — otherwise
+    an attacker publishes one public address to satisfy the check and one
+    private address for the connection to actually use.
+    """
+    addresses = await _resolve(host)
+    if not addresses:
+        raise BlockedURL(f"could not resolve {host!r}")
+
+    for raw in addresses:
+        try:
+            ip = ipaddress.ip_address(raw)
+        except ValueError as exc:  # pragma: no cover - getaddrinfo shouldn't
+            raise BlockedURL(f"unparseable address {raw!r} for {host!r}") from exc
+        if _is_forbidden(ip):
+            raise BlockedURL(f"{host!r} resolves to non-public address {ip}")
+
+
+async def _validate(url: str) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise BlockedURL(f"unsupported scheme: {parsed.scheme!r}")
+    if not parsed.hostname:
+        raise BlockedURL("URL has no hostname")
+    await _assert_public(parsed.hostname)
+
+
+def _make_client(
+    transport: Optional[httpx.AsyncBaseTransport] = None,
+) -> httpx.AsyncClient:
+    """Build the fetch client. `transport` is a seam for tests."""
+    return httpx.AsyncClient(
+        follow_redirects=False,
+        timeout=_TIMEOUT,
+        headers={"User-Agent": _USER_AGENT},
+        transport=transport,
+    )
+
+
+async def fetch_page(url: str) -> str:
+    """Fetch a page as text, re-validating the target on every redirect hop.
+
+    Redirects are followed by hand rather than by httpx: a page that passes the
+    guard can still answer 302 to somewhere private, and httpx's own redirect
+    handling would never re-check.
+    """
+    async with _make_client() as client:
+        for _ in range(_MAX_REDIRECTS):
+            await _validate(url)
+            try:
+                async with client.stream("GET", url) as response:
+                    if response.is_redirect:
+                        location = response.headers.get("location")
+                        if not location:
+                            raise BlockedURL("redirect with no Location header")
+                        url = str(response.url.join(location))
+                        continue
+
+                    if response.status_code >= 400:
+                        raise FetchFailed(
+                            f"{url} returned HTTP {response.status_code}"
+                        )
+
+                    # Enforced while streaming — a Content-Length check would
+                    # trust a header the origin controls.
+                    chunks: list[bytes] = []
+                    total = 0
+                    async for chunk in response.aiter_bytes():
+                        total += len(chunk)
+                        if total > _MAX_BYTES:
+                            raise BlockedURL(
+                                f"response exceeded {_MAX_BYTES} bytes"
+                            )
+                        chunks.append(chunk)
+            except httpx.InvalidURL as exc:
+                # Redirect targets are attacker-controlled, so a Location that
+                # httpx refuses to parse is a rejection, not a fetch failure.
+                raise BlockedURL(f"unusable URL {url!r}: {exc}") from exc
+            except httpx.HTTPError as exc:
+                raise FetchFailed(f"could not fetch {url}: {exc}") from exc
+
+            return b"".join(chunks).decode(
+                response.encoding or "utf-8", errors="replace"
+            )
+
+    raise BlockedURL(f"more than {_MAX_REDIRECTS} redirects")
+
+
+# --- Parsing ---
+
+_T = TypeVar("_T")
+
+
+def _maybe(getter: Callable[[], _T]) -> Optional[_T]:
+    """Call an optional scraper field, treating any failure as absent.
+
+    recipe-scrapers raises rather than returning None for fields a given site
+    doesn't publish, and every one of these is optional for us.
+    """
+    try:
+        value = getter()
+    except Exception:
+        return None
+    return value or None
+
+
+def _parse_servings(raw: Optional[str]) -> Optional[int]:
+    """Pull a serving count out of a yields string.
+
+    recipe-scrapers normalises before we see it — ``"serves 4-6"`` arrives as
+    ``"6 servings"`` (it takes the upper bound of a range) — so the first
+    integer in the string is the one we want.
+    """
+    if not raw:
+        return None
+    match = re.search(r"\d+", raw)
+    if not match:
+        return None
+    value = int(match.group())
+    if value < 1 or value > _MAX_PLAUSIBLE_SERVINGS:
+        return None
+    return value
+
+
+def _clean_lines(values: Optional[list[str]]) -> list[str]:
+    if not values:
+        return []
+    return [line.strip() for line in values if line and line.strip()]
+
+
+def scrape(html: str, url: str) -> Optional[ScrapedRecipe]:
+    """Parse a recipe out of already-fetched HTML.
+
+    Returns None when the page publishes no recipe data we can read, which is
+    the caller's signal to fall back to the model.
+
+    supported_only=False is always passed (it replaces the deprecated
+    wild_mode): the site's dedicated scraper is still used when one exists,
+    and generic schema.org parsing handles everything else, so it is a strict
+    superset of the supported-sites-only behaviour.
+    """
+    try:
+        scraper = scrape_html(html, org_url=url, supported_only=False)
+    except (NoSchemaFoundInWildMode, WebsiteNotImplementedError):
+        return None
+
+    title = _maybe(scraper.title)
+    instructions = _clean_lines(_maybe(scraper.instructions_list))
+    ingredients = _clean_lines(_maybe(scraper.ingredients))
+
+    # A recipe with no title, no steps or no ingredients isn't usable, and
+    # partial schema.org markup on non-recipe pages is common enough to matter.
+    if not title or not instructions or not ingredients:
+        return None
+
+    groups: list[IngredientGroup] = []
+    raw_groups = _maybe(scraper.ingredient_groups) or []
+    for raw_group in raw_groups:
+        group_ingredients = _clean_lines(getattr(raw_group, "ingredients", None))
+        if group_ingredients:
+            groups.append(
+                IngredientGroup(
+                    purpose=getattr(raw_group, "purpose", None),
+                    ingredients=group_ingredients,
+                )
+            )
+
+    return ScrapedRecipe(
+        title=title.strip(),
+        instructions=instructions,
+        ingredients=ingredients,
+        source_url=url,
+        ingredient_groups=groups,
+        servings=_parse_servings(_maybe(scraper.yields)),
+        prep_minutes=_maybe(scraper.prep_time),
+        cook_minutes=_maybe(scraper.cook_time),
+        total_minutes=_maybe(scraper.total_time),
+        image_url=_maybe(scraper.image),
+        source_name=_maybe(scraper.host) or urlparse(url).hostname,
+        description=_maybe(scraper.description),
+        cuisine=_maybe(scraper.cuisine),
+    )
+
+
+async def import_from_url(url: str) -> Optional[ScrapedRecipe]:
+    """Fetch and parse in one step. Raises BlockedURL / FetchFailed."""
+    return scrape(await fetch_page(url), url)

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -57,6 +57,7 @@ beanie>=1.26,<2
 python-dotenv==1.2.1
 python-multipart==0.0.22
 PyYAML==6.0.3
+recipe-scrapers==15.11.0
 requests==2.32.5
 requests-toolbelt==1.0.0
 rich==14.3.3

--- a/server/tests/fixtures/recipe_jsonld.html
+++ b/server/tests/fixtures/recipe_jsonld.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en-GB">
+<head>
+<meta charset="utf-8">
+<title>Classic lasagne recipe | Good Food</title>
+<meta property="og:title" content="Classic lasagne">
+<meta property="og:image" content="https://images.example.com/og-lasagne.jpg">
+<link rel="canonical" href="https://www.bbcgoodfood.com/recipes/classic-lasagne">
+<script>window.dataLayer=[{"pageType":"recipe"}];</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebSite",
+      "name": "Good Food",
+      "url": "https://www.bbcgoodfood.com/"
+    },
+    {
+      "@type": "Recipe",
+      "name": "Classic Lasagne",
+      "image": ["https://images.example.com/lasagne.jpg"],
+      "author": {"@type": "Person", "name": "Esther Clark"},
+      "datePublished": "2021-03-01",
+      "description": "A proper family favourite, with a rich ragù and a silky white sauce.",
+      "prepTime": "PT30M",
+      "cookTime": "PT1H30M",
+      "totalTime": "PT2H",
+      "recipeYield": "6 servings",
+      "recipeCategory": "Dinner",
+      "recipeCuisine": "Italian",
+      "aggregateRating": {"@type": "AggregateRating", "ratingValue": "4.7", "ratingCount": "212"},
+      "nutrition": {"@type": "NutritionInformation", "calories": "636 calories", "fatContent": "33 grams fat"},
+      "recipeIngredient": [
+        "1 tbsp olive oil",
+        "2 onions, finely chopped",
+        "3 garlic cloves, crushed",
+        "500g beef mince",
+        "400g can chopped tomatoes",
+        "250g lasagne sheets",
+        "500ml whole milk",
+        "50g butter",
+        "50g plain flour",
+        "100g cheddar, grated"
+      ],
+      "recipeInstructions": [
+        {"@type": "HowToStep", "text": "Heat the 1 tbsp olive oil in a large pan and fry the 2 onions until soft, about 10 mins."},
+        {"@type": "HowToStep", "text": "Add the 3 garlic cloves and 500g beef mince and brown all over."},
+        {"@type": "HowToStep", "text": "Stir in the 400g chopped tomatoes and simmer for 45 mins."},
+        {"@type": "HowToStep", "text": "Make the white sauce with the 50g butter, 50g plain flour and 500ml whole milk."},
+        {"@type": "HowToStep", "text": "Layer with the 250g lasagne sheets, top with the 100g cheddar and bake for 45 mins."}
+      ]
+    }
+  ]
+}
+</script>
+</head>
+<body>
+<div id="cookie-banner">We use cookies. <button>Accept</button></div>
+<nav><ul><li><a href="/recipes">Recipes</a></li><li><a href="/health">Health</a></li></ul></nav>
+<div class="ad-slot" data-ad="leaderboard"></div>
+<article>
+  <h1>Classic lasagne</h1>
+  <p class="standfirst">A proper family favourite.</p>
+  <p>Before we get to the recipe, a word about my grandmother's kitchen in 1974,
+     the smell of soffritto, and why every good lasagne begins with patience.</p>
+  <section class="ingredients"><h2>Ingredients</h2><ul><li>1 tbsp olive oil</li></ul></section>
+  <section class="method"><h2>Method</h2><ol><li>Heat the oil.</li></ol></section>
+  <section class="comments"><h2>Comments (212)</h2><p>Made this last night, delicious!</p></section>
+</article>
+<footer><p>&copy; Example Media</p></footer>
+</body>
+</html>

--- a/server/tests/test_recipe_import.py
+++ b/server/tests/test_recipe_import.py
@@ -1,0 +1,381 @@
+import json
+from pathlib import Path
+from unittest.mock import patch
+from urllib.parse import urlparse
+
+import httpx
+import pytest
+
+import recipe_import
+from recipe_import import (
+    BlockedURL,
+    FetchFailed,
+    _is_forbidden,
+    _parse_servings,
+    fetch_page,
+    scrape,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def build_page(**overrides) -> str:
+    """A minimal page carrying a schema.org/Recipe JSON-LD block."""
+    recipe = {
+        "@context": "https://schema.org",
+        "@type": "Recipe",
+        "name": "Classic Lasagne",
+        "image": ["https://images.example.com/lasagne.jpg"],
+        "description": "A proper family favourite.",
+        "prepTime": "PT30M",
+        "cookTime": "PT1H30M",
+        "totalTime": "PT2H",
+        "recipeYield": "6 servings",
+        "recipeCuisine": "Italian",
+        "recipeIngredient": ["1 tbsp olive oil", "500g beef mince"],
+        "recipeInstructions": [
+            {"@type": "HowToStep", "text": "Fry the onions."},
+            {"@type": "HowToStep", "text": "Bake for 45 mins."},
+        ],
+    }
+    recipe.update(overrides)
+    for key in [k for k, v in recipe.items() if v is None]:
+        del recipe[key]
+    return (
+        '<html><head><script type="application/ld+json">'
+        f"{json.dumps(recipe)}"
+        "</script></head><body><p>blog preamble</p></body></html>"
+    )
+
+
+def patch_resolve(mapping: dict[str, list[str]]):
+    """Patch DNS so resolution is deterministic and offline."""
+
+    async def fake_resolve(host: str) -> list[str]:
+        if host not in mapping:
+            raise BlockedURL(f"could not resolve {host!r}")
+        return mapping[host]
+
+    return patch.object(recipe_import, "_resolve", fake_resolve)
+
+
+def patch_transport(handler):
+    """Route fetches through a MockTransport, keeping the real client config."""
+    real_make_client = recipe_import._make_client
+
+    def make_client() -> httpx.AsyncClient:
+        return real_make_client(transport=httpx.MockTransport(handler))
+
+    return patch.object(recipe_import, "_make_client", make_client)
+
+
+# --- SSRF guard: address classification ---
+
+
+class TestIsForbidden:
+    @pytest.mark.parametrize(
+        "address",
+        [
+            "127.0.0.1",  # loopback
+            "10.0.0.5",  # private
+            "172.16.4.1",  # private
+            "192.168.1.1",  # private
+            "169.254.169.254",  # cloud metadata
+            "0.0.0.0",  # unspecified
+            "224.0.0.1",  # multicast
+            "::1",  # v6 loopback
+            "fd00::1",  # v6 unique-local
+            "fe80::1",  # v6 link-local
+            "::ffff:127.0.0.1",  # IPv4-mapped loopback
+            "::ffff:169.254.169.254",  # IPv4-mapped metadata
+        ],
+    )
+    def test_rejects_non_public(self, address):
+        import ipaddress
+
+        assert _is_forbidden(ipaddress.ip_address(address)) is True
+
+    @pytest.mark.parametrize(
+        "address",
+        ["93.184.216.34", "8.8.8.8", "2606:2800:220:1:248:1893:25c8:1946"],
+    )
+    def test_allows_public(self, address):
+        import ipaddress
+
+        assert _is_forbidden(ipaddress.ip_address(address)) is False
+
+    def test_unwraps_ipv4_mapped_before_classifying(self):
+        """Why the unwrap exists.
+
+        CPython's classification of IPv4-mapped IPv6 has changed across patch
+        releases (CVE-2024-4032 altered is_private/is_global), and this runs on
+        3.11 locally but 3.12 in production. Normalising to the embedded IPv4
+        address makes the verdict ours rather than the stdlib's.
+        """
+        import ipaddress
+
+        mapped = ipaddress.ip_address("::ffff:169.254.169.254")
+        assert mapped.ipv4_mapped == ipaddress.ip_address("169.254.169.254")
+        assert _is_forbidden(mapped) is True
+
+
+# --- SSRF guard: end-to-end through fetch_page ---
+
+
+class TestFetchGuard:
+    async def test_rejects_non_http_scheme(self):
+        with pytest.raises(BlockedURL, match="scheme"):
+            await fetch_page("file:///etc/passwd")
+
+    async def test_rejects_url_without_host(self):
+        with pytest.raises(BlockedURL):
+            await fetch_page("http:///nohost")
+
+    @pytest.mark.parametrize(
+        "url,resolved",
+        [
+            ("http://localhost:8000/", "127.0.0.1"),
+            ("http://169.254.169.254/latest/meta-data/", "169.254.169.254"),
+            ("http://omlete-client.railway.internal/", "fd12::1"),
+            ("http://internal.example/", "10.1.2.3"),
+        ],
+    )
+    async def test_rejects_private_targets(self, url, resolved):
+        host = urlparse(url).hostname
+        with patch_resolve({host: [resolved]}):
+            with pytest.raises(BlockedURL, match="non-public"):
+                await fetch_page(url)
+
+    @pytest.mark.parametrize(
+        "url", ["http://0177.0.0.1/", "http://2130706433/", "http://127.1/"]
+    )
+    async def test_rejects_encoded_loopback_forms(self, url):
+        """Encoded forms resolve to loopback; string matching would miss them."""
+        host = urlparse(url).hostname
+        with patch_resolve({host: ["127.0.0.1"]}):
+            with pytest.raises(BlockedURL, match="non-public"):
+                await fetch_page(url)
+
+    async def test_rejects_when_any_resolved_address_is_private(self):
+        """A public A record does not excuse a private AAAA record."""
+        with patch_resolve({"dual.example": ["93.184.216.34", "10.0.0.1"]}):
+            with pytest.raises(BlockedURL, match="non-public"):
+                await fetch_page("http://dual.example/r")
+
+    async def test_rejects_unresolvable_host(self):
+        with patch_resolve({}):
+            with pytest.raises(BlockedURL, match="resolve"):
+                await fetch_page("http://nope.example/r")
+
+    async def test_revalidates_after_redirect(self):
+        """The hop that matters: public host 302s to the metadata endpoint."""
+        calls = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls.append(str(request.url))
+            return httpx.Response(
+                302, headers={"location": "http://169.254.169.254/"}
+            )
+
+        resolve = {
+            "safe.example": ["93.184.216.34"],
+            "169.254.169.254": ["169.254.169.254"],
+        }
+        with patch_resolve(resolve), patch_transport(handler):
+            with pytest.raises(BlockedURL, match="non-public"):
+                await fetch_page("http://safe.example/r")
+
+        # The first hop was fetched; the second was blocked before any request.
+        assert calls == ["http://safe.example/r"]
+
+    async def test_rejects_redirect_without_location(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(302)
+
+        with patch_resolve({"safe.example": ["93.184.216.34"]}), patch_transport(
+            handler
+        ):
+            with pytest.raises(BlockedURL, match="Location"):
+                await fetch_page("http://safe.example/r")
+
+    async def test_caps_redirect_chain(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(302, headers={"location": "/next"})
+
+        with patch_resolve({"safe.example": ["93.184.216.34"]}), patch_transport(
+            handler
+        ):
+            with pytest.raises(BlockedURL, match="redirects"):
+                await fetch_page("http://safe.example/r")
+
+    async def test_caps_response_size(self):
+        oversized = b"x" * (recipe_import._MAX_BYTES + 1)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=oversized)
+
+        with patch_resolve({"safe.example": ["93.184.216.34"]}), patch_transport(
+            handler
+        ):
+            with pytest.raises(BlockedURL, match="exceeded"):
+                await fetch_page("http://safe.example/big")
+
+    async def test_raises_fetch_failed_on_http_error(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404)
+
+        with patch_resolve({"safe.example": ["93.184.216.34"]}), patch_transport(
+            handler
+        ):
+            with pytest.raises(FetchFailed, match="404"):
+                await fetch_page("http://safe.example/missing")
+
+    async def test_raises_fetch_failed_on_transport_error(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("refused")
+
+        with patch_resolve({"safe.example": ["93.184.216.34"]}), patch_transport(
+            handler
+        ):
+            with pytest.raises(FetchFailed):
+                await fetch_page("http://safe.example/r")
+
+    async def test_fetches_a_public_page(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert "OmleteBot" in request.headers["user-agent"]
+            return httpx.Response(200, text="<html>hi</html>")
+
+        with patch_resolve({"safe.example": ["93.184.216.34"]}), patch_transport(
+            handler
+        ):
+            assert await fetch_page("http://safe.example/r") == "<html>hi</html>"
+
+
+# --- Servings parsing ---
+
+
+class TestParseServings:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("6 servings", 6),
+            ("Serves 4", 4),
+            ("Makes 12 cookies", 12),
+            ("1 loaf", 1),
+            (None, None),
+            ("", None),
+            ("a few", None),
+            ("0 servings", None),
+            ("2024 servings", None),  # implausible, likely a misparse
+        ],
+    )
+    def test_parses(self, raw, expected):
+        assert _parse_servings(raw) == expected
+
+
+# --- Scraping ---
+
+
+class TestScrape:
+    def test_extracts_a_full_recipe(self):
+        result = scrape(build_page(), "https://food.example/lasagne")
+
+        assert result is not None
+        assert result.title == "Classic Lasagne"
+        assert result.instructions == ["Fry the onions.", "Bake for 45 mins."]
+        assert result.ingredients == ["1 tbsp olive oil", "500g beef mince"]
+        assert result.servings == 6
+        assert result.prep_minutes == 30
+        assert result.cook_minutes == 90
+        assert result.total_minutes == 120
+        assert result.image_url == "https://images.example.com/lasagne.jpg"
+        assert result.cuisine == "Italian"
+        assert result.source_url == "https://food.example/lasagne"
+
+    def test_ingredients_stay_free_text(self):
+        """Stage 1 does not decompose ingredients — that's stage 2's job."""
+        page = build_page(recipeIngredient=["2 onions, finely chopped"])
+        result = scrape(page, "https://food.example/r")
+
+        assert result is not None
+        assert result.ingredients == ["2 onions, finely chopped"]
+
+    def test_returns_none_without_structured_data(self):
+        html = "<html><body><p>Just a blog post about my holiday.</p></body></html>"
+        assert scrape(html, "https://blog.example/post") is None
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"recipeIngredient": []},
+            {"recipeInstructions": []},
+            {"name": None},
+        ],
+        ids=["no-ingredients", "no-instructions", "no-title"],
+    )
+    def test_returns_none_when_essentials_missing(self, overrides):
+        assert scrape(build_page(**overrides), "https://food.example/r") is None
+
+    def test_optional_fields_absent_is_fine(self):
+        page = build_page(
+            image=None,
+            prepTime=None,
+            cookTime=None,
+            totalTime=None,
+            recipeYield=None,
+            recipeCuisine=None,
+            description=None,
+        )
+        result = scrape(page, "https://food.example/r")
+
+        assert result is not None
+        assert result.title == "Classic Lasagne"
+        assert result.servings is None
+        assert result.prep_minutes is None
+        assert result.image_url is None
+        assert result.cuisine is None
+
+    def test_takes_upper_bound_of_a_yield_range(self):
+        """Documents recipe-scrapers' behaviour rather than endorsing it."""
+        result = scrape(
+            build_page(recipeYield="serves 4-6"), "https://food.example/r"
+        )
+
+        assert result is not None
+        assert result.servings == 6
+
+    def test_strips_whitespace_and_blank_lines(self):
+        page = build_page(
+            recipeIngredient=["  1 tbsp olive oil  ", "", "   "],
+            recipeInstructions=[
+                {"@type": "HowToStep", "text": "  Fry the onions.  "}
+            ],
+        )
+        result = scrape(page, "https://food.example/r")
+
+        assert result is not None
+        assert result.ingredients == ["1 tbsp olive oil"]
+        assert result.instructions == ["Fry the onions."]
+
+    def test_populates_ingredient_groups(self):
+        result = scrape(build_page(), "https://food.example/r")
+
+        assert result is not None
+        assert len(result.ingredient_groups) == 1
+        assert result.ingredient_groups[0].ingredients == [
+            "1 tbsp olive oil",
+            "500g beef mince",
+        ]
+
+    def test_parses_a_realistic_saved_page(self):
+        """Guards against markup noise a hand-built fixture wouldn't have."""
+        html = (FIXTURES / "recipe_jsonld.html").read_text()
+        result = scrape(html, "https://www.bbcgoodfood.com/recipes/classic-lasagne")
+
+        assert result is not None
+        assert result.title == "Classic Lasagne"
+        assert len(result.ingredients) == 10
+        assert len(result.instructions) == 5
+        assert result.servings == 6
+        assert result.total_minutes == 120
+        assert result.source_name == "bbcgoodfood.com"


### PR DESCRIPTION
## Summary

This PR adds three comprehensive documentation files that establish the strategic and technical foundation for the next phase of Omlete development:

1. **PRD_URL_IMPORT.md** — A complete product requirements document for importing recipes from web links, the single highest-leverage missing feature
2. **GAP_ANALYSIS.md** — A codebase audit and competitive gap analysis against Paprika, AnyList, Tandoor, and the AI-native cohort
3. **WHISK_ANALYSIS.md** — A deep dive into Samsung Food (formerly Whisk) as the closest architectural comparator, with specific differentiation opportunities

## Key Changes

### PRD_URL_IMPORT.md (443 lines)
- **Problem statement**: Pasting a link is how people actually acquire recipes; every competitor supports it, but Omlete doesn't
- **Two-stage architecture**: Stage 1 (scrape with `recipe-scrapers`, ~1s, zero tokens) → Stage 2 (structure ingredients with Haiku)
- **Verified findings**: Tested against `recipe-scrapers` 15.11.0; 583 scrapers available; UK site coverage confirmed (BBC Good Food, Jamie Oliver, Waitrose, etc.)
- **Technical design**: 
  - New `server/recipe_import.py` module with SSRF-guarded async fetch and scraping
  - New `server/ingredient_structurer.py` using Haiku for ingredient parsing
  - `POST /api/recipes/import-from-url/` endpoint with fallback to existing Opus path
  - Model extensions: `source_url`, `source_name`, `image_url`, times, servings
- **UX**: New "From link" tab on `/create` (default), PWA share target for Android
- **Implementation plan**: 8-step sequence with testing strategy and verification checklist
- **Appendix A**: Full SSRF threat model and reference implementation (the critical security piece)

### GAP_ANALYSIS.md (291 lines)
- **Current state**: Omlete is "a shopping-list app with an AI recipe importer attached," not yet a recipe manager
- **Strengths**: Ingredient canonicalisation via embeddings (unique in the field), source-tracked shopping lists, plan vs shop modes
- **Data model audit**: Reveals missing fields (servings, times, photos, source URL, tags, cuisine, nutrition)
- **Competitive matrix**: Feature comparison across Paprika, AnyList, Tandoor, and AI-native cohort
- **Top 10 gaps ranked by impact**:
  1. No URL import (highest leverage)
  2. No recipe photos
  3. No search/tags/filtering
  4. No servings/scaling
  5. No times or metadata
  6. No meal-plan calendar
  7. No cook mode
  8. No pantry
  9. No auth/users/sharing
  10. No offline support
- **Engineering risks**: Unauthenticated LLM endpoints (open wallet), zero database indexes, N+1 queries, missing error handling, blocking requests with no progress

### WHISK_ANALYSIS.md (230 lines)
- **Context**: Whisk (acquired by Samsung in 2019) is the closest architectural precedent; $39M spent building the Food Genome
- **Food Genome axes**: Identity, products, nutrition, perishability, flavour, availability
- **Key insight**: Ingredient identity (Whisk's original moat) is now commoditised by embeddings; Omlete already has this
- **Samsung Food feature inventory**: URL import, 160k–240k recipes, AI transformation, vision AI, meal planner, shoppable lists (29 retailers), nutrition, communities, health integration
- **Samsung Food weaknesses** (7 specific openings):
  - Serving-size changes don't propagate to shopping lists (Omlete's `ItemSource` already solves this)
  - No leftovers/batch-cooking model
  - Pantry paywalled and basic
  - One grocery store per list
  - Health Score actively disliked
  - Post-acquisition decay (bugs unfixed, broken browser extension)
  - Device bias (Galaxy-only features)
- **Om

https://claude.ai/code/session_01352ZFUdz7REfvarGP5qZfp