### PR TITLE
Import a recipe from a link

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,17 +33,29 @@ Python 3.12 required. Install deps: `pip install -r requirements.txt`.
 - Route tree auto-generated at `src/routeTree.gen.ts` — do not edit manually
 
 ### Backend (`/server/`)
-- **FastAPI** with two endpoints: `POST /recipes/generate/` and `POST /recipes/extract-from-images/`
-- **Beanie** (async MongoDB ODM) with two document types in `data_models/`: `IngredientDocument` (with 2048-dim Voyage-4 embeddings) and `RecipeDocument`
+- **FastAPI**, all routes under an `/api` prefix in `main.py`. Three ways to create a recipe: `POST /recipes/generate/` (from an ingredient list), `POST /recipes/extract-from-images/` (from photos), and `POST /recipes/import-from-url/` (from a link). The rest of the file is CRUD for recipes, lists, list items and categories.
+- **Beanie** (async MongoDB ODM) with four document types in `data_models/`: `IngredientDocument` (with 2048-dim Voyage-4 embeddings), `RecipeDocument`, `ListDocument` and `UserSettingsDocument`
 - `tools.py` — defines the `find_similar_ingredients` Claude tool, which runs a MongoDB `$vectorSearch` to find semantically similar existing ingredients (threshold ≥ 0.9)
+- `recipe_import.py` — SSRF-guarded page fetch + `recipe-scrapers` parsing (stage 1 of URL import)
+- `ingredient_structurer.py` — Haiku pass that turns free-text ingredient lines into structured ingredients (stage 2 of URL import)
 - `lib/db.py` — MongoDB connection (Motor) and Voyage AI client setup
 
 ### AI / Data Flow
+
+Generate and extract both go straight to Opus:
 1. Request hits FastAPI → images encoded to base64 if needed
 2. Claude Opus 4.5 called with system prompt + `find_similar_ingredients` tool
 3. Claude generates structured JSON recipe, calling the tool for ingredient lookups
 4. New ingredients embedded via Voyage AI and saved to MongoDB
 5. Recipe document saved and returned as JSON
+
+URL import is two stages, and the cheap one does most of the work:
+1. `recipe_import.fetch_page()` fetches the page behind an SSRF guard, `scrape()` reads its schema.org data — title, instructions, image, times, servings. No tokens.
+2. `ingredient_structurer.structure_ingredients()` splits the free-text ingredient lines into name/amount/unit on Haiku, calling `find_similar_ingredients` to canonicalise
+3. Pages that publish no structured data fall back to Opus over the page text
+4. Saved via the same `_save_recipe()` path as everything else, plus a `RecipeMetadata` carrying the provenance
+
+See `docs/PRD_URL_IMPORT.md` for the design and what's still outstanding.
 
 ### Deployment
 - `render.yaml` defines two Render services: `omlete-api` (Python) and `omlete-client` (Node)

--- a/client/src/components/RecipeCard.tsx
+++ b/client/src/components/RecipeCard.tsx
@@ -1,41 +1,96 @@
 import { highlightAmounts } from '@/lib/highlightAmounts'
+import { groupIngredients } from '@/lib/groupIngredients'
+import { RecipeHeroImage, RecipeMetaRow } from '@/components/RecipeMetaRow'
+import type { RecipeMetadata } from '@/components/RecipeMetaRow'
 
-type IngredientRecipe = { name: string; unit: string; amount: number | null; category?: string; excluded_from_list?: boolean }
-export type Recipe = { title: string; instructions: string[]; ingredients: IngredientRecipe[] }
+type IngredientRecipe = {
+  name: string
+  unit: string
+  // null when the recipe never gave a quantity — "salt and pepper to taste".
+  amount: number | null
+  note?: string | null
+  group?: string | null
+  category?: string
+  excluded_from_list?: boolean
+}
+
+export type Recipe = RecipeMetadata & {
+  title: string
+  instructions: string[]
+  ingredients: IngredientRecipe[]
+}
+
+function formatAmount(ing: IngredientRecipe): string {
+  if (ing.amount == null) return ing.unit
+  return `${ing.amount} ${ing.unit}`.trim()
+}
 
 export function RecipeCard({ recipe }: { recipe: Recipe }) {
+  const groups = groupIngredients(recipe.ingredients)
+
   return (
-    <div className="bg-white border border-line rounded-xl p-6 space-y-5 shadow-sm">
-      <h2 className="text-xl font-semibold text-ink">{recipe.title}</h2>
+    <div className="bg-white border border-line rounded-xl overflow-hidden shadow-sm">
+      {recipe.image_url && (
+        <RecipeHeroImage
+          src={recipe.image_url}
+          alt={recipe.title}
+          className="h-48 sm:h-56"
+        />
+      )}
 
-      <div>
-        <h3 className="text-xs font-semibold text-ink-muted uppercase tracking-wider mb-3">
-          Ingredients
-        </h3>
-        <ul className="space-y-1.5">
-          {recipe.ingredients.map((ing, i) => (
-            <li key={i} className="text-sm text-ink-soft flex gap-2">
-              <span className="flex-1">{ing.name}</span>
-              <span className="text-ink font-medium shrink-0">
-                {ing.amount == null ? ing.unit : `${ing.amount} ${ing.unit}`}
-              </span>
-            </li>
-          ))}
-        </ul>
-      </div>
+      <div className="p-6 space-y-5">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-ink">{recipe.title}</h2>
+          <RecipeMetaRow recipe={recipe} />
+        </div>
 
-      <div>
-        <h3 className="text-xs font-semibold text-ink-muted uppercase tracking-wider mb-3">
-          Instructions
-        </h3>
-        <ol className="space-y-2.5">
-          {recipe.instructions.map((step, i) => (
-            <li key={i} className="text-sm text-ink-soft flex gap-3">
-              <span className="text-ink-faint font-mono shrink-0 pt-px">{i + 1}.</span>
-              <span>{highlightAmounts(step)}</span>
-            </li>
-          ))}
-        </ol>
+        <div>
+          <h3 className="text-xs font-semibold text-ink-muted uppercase tracking-wider mb-3">
+            Ingredients
+          </h3>
+          <div className="space-y-4">
+            {groups.map((group) => (
+              <div key={group.heading || 'ungrouped'}>
+                {group.heading && (
+                  <h4 className="text-xs font-medium text-ink-soft mb-2">
+                    {group.heading}
+                  </h4>
+                )}
+                <ul className="space-y-1.5">
+                  {group.items.map(({ ingredient, index }) => (
+                    <li key={index} className="text-sm text-ink-soft flex gap-2">
+                      <span className="flex-1">
+                        {ingredient.name}
+                        {ingredient.note && (
+                          <span className="text-ink-faint">, {ingredient.note}</span>
+                        )}
+                      </span>
+                      <span className="text-ink font-medium shrink-0">
+                        {formatAmount(ingredient)}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <h3 className="text-xs font-semibold text-ink-muted uppercase tracking-wider mb-3">
+            Instructions
+          </h3>
+          <ol className="space-y-2.5">
+            {recipe.instructions.map((step, i) => (
+              <li key={i} className="text-sm text-ink-soft flex gap-3">
+                <span className="text-ink-faint font-mono shrink-0 pt-px">
+                  {i + 1}.
+                </span>
+                <span>{highlightAmounts(step)}</span>
+              </li>
+            ))}
+          </ol>
+        </div>
       </div>
     </div>
   )

--- a/client/src/components/RecipeCard.tsx
+++ b/client/src/components/RecipeCard.tsx
@@ -1,6 +1,6 @@
 import { highlightAmounts } from '@/lib/highlightAmounts'
 
-type IngredientRecipe = { name: string; unit: string; amount: number; category?: string; excluded_from_list?: boolean }
+type IngredientRecipe = { name: string; unit: string; amount: number | null; category?: string; excluded_from_list?: boolean }
 export type Recipe = { title: string; instructions: string[]; ingredients: IngredientRecipe[] }
 
 export function RecipeCard({ recipe }: { recipe: Recipe }) {
@@ -17,7 +17,7 @@ export function RecipeCard({ recipe }: { recipe: Recipe }) {
             <li key={i} className="text-sm text-ink-soft flex gap-2">
               <span className="flex-1">{ing.name}</span>
               <span className="text-ink font-medium shrink-0">
-                {ing.amount} {ing.unit}
+                {ing.amount == null ? ing.unit : `${ing.amount} ${ing.unit}`}
               </span>
             </li>
           ))}

--- a/client/src/components/RecipeMetaRow.tsx
+++ b/client/src/components/RecipeMetaRow.tsx
@@ -1,0 +1,97 @@
+import { Clock, ExternalLink, Users } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+/** Provenance and timings — only ever populated by a URL import. */
+export type RecipeMetadata = {
+  servings?: number | null
+  prep_minutes?: number | null
+  cook_minutes?: number | null
+  total_minutes?: number | null
+  image_url?: string | null
+  source_url?: string | null
+  source_name?: string | null
+  description?: string | null
+  cuisine?: string | null
+}
+
+export function formatMinutes(minutes: number): string {
+  if (minutes < 60) return `${minutes} min`
+  const hours = Math.floor(minutes / 60)
+  const rest = minutes % 60
+  return rest === 0 ? `${hours} hr` : `${hours} hr ${rest} min`
+}
+
+/**
+ * Time, servings and attribution for an imported recipe.
+ *
+ * Renders nothing at all when none of it is set, which is the case for every
+ * recipe created by hand or from photos — the row should not leave a gap in
+ * layouts it has nothing to say in.
+ */
+export function RecipeMetaRow({ recipe }: { recipe: RecipeMetadata }) {
+  const time = recipe.total_minutes ?? recipe.cook_minutes
+  const hasAnything = time != null || recipe.servings != null || recipe.source_url
+
+  if (!hasAnything) return null
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 text-sm text-ink-muted">
+      {time != null && (
+        <span className="flex items-center gap-1.5">
+          <Clock className="size-3.5 shrink-0" />
+          {formatMinutes(time)}
+        </span>
+      )}
+
+      {recipe.servings != null && (
+        <span className="flex items-center gap-1.5">
+          <Users className="size-3.5 shrink-0" />
+          Serves {recipe.servings}
+        </span>
+      )}
+
+      {recipe.source_url && (
+        <a
+          href={recipe.source_url}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="flex items-center gap-1.5 hover:text-ink-soft underline underline-offset-4 transition-colors min-w-0"
+        >
+          <ExternalLink className="size-3.5 shrink-0" />
+          <span className="truncate">{recipe.source_name || 'Source'}</span>
+        </a>
+      )}
+    </div>
+  )
+}
+
+/**
+ * The hero image from the source page.
+ *
+ * We store the origin's URL rather than re-hosting, so this can rot. It hides
+ * itself on error instead of leaving a broken-image icon in the layout.
+ */
+export function RecipeHeroImage({
+  src,
+  alt,
+  className,
+}: {
+  src: string
+  alt: string
+  className?: string
+}) {
+  return (
+    <img
+      src={src}
+      alt={alt}
+      loading="lazy"
+      onError={(e) => {
+        e.currentTarget.style.display = 'none'
+      }}
+      // Sizing belongs to the caller — a list row wants a 64px square, a card
+      // wants full width. `cn` merges rather than concatenates, so a caller's
+      // `size-16` actually beats the default `w-full` instead of losing to it.
+      className={cn('w-full object-cover bg-mist', className)}
+    />
+  )
+}

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -7,3 +7,36 @@ const apiBase =
 export function apiFetch(path: string, init?: RequestInit): Promise<Response> {
   return fetch(`${apiBase}${path}`, init);
 }
+
+/** An HTTP error carrying the status and FastAPI's `detail` payload. */
+export class ApiError extends Error {
+  constructor(
+    readonly status: number,
+    readonly detail: unknown,
+  ) {
+    super(typeof detail === "string" ? detail : `Request failed (${status})`);
+    this.name = "ApiError";
+  }
+}
+
+/**
+ * `apiFetch` that rejects on a non-2xx instead of handing back an error body
+ * for the caller to render as if it were data. `fetch` only rejects on a
+ * network failure, so callers using it directly treat a 502 as success.
+ */
+export async function apiJson<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await apiFetch(path, init);
+
+  if (!res.ok) {
+    let detail: unknown = null;
+    try {
+      detail = ((await res.json()) as { detail?: unknown }).detail ?? null;
+    } catch {
+      // A proxy or gateway error won't be JSON. The status still tells us
+      // enough to show something useful.
+    }
+    throw new ApiError(res.status, detail);
+  }
+
+  return res.json() as Promise<T>;
+}

--- a/client/src/lib/groupIngredients.ts
+++ b/client/src/lib/groupIngredients.ts
@@ -1,0 +1,26 @@
+/**
+ * Split ingredients into the runs the source page had them in.
+ *
+ * URL imports carry the "For the sauce:" headings through from the origin;
+ * everything else has no groups at all and collapses to a single unnamed run.
+ * The original array index rides along because callers act on ingredients by
+ * position (excluding one from a shopping list, for instance), and grouping
+ * must not renumber them.
+ */
+export function groupIngredients<T extends { group?: string | null }>(
+  ingredients: T[],
+): Array<{ heading: string; items: Array<{ ingredient: T; index: number }> }> {
+  const groups: Array<{
+    heading: string
+    items: Array<{ ingredient: T; index: number }>
+  }> = []
+
+  ingredients.forEach((ingredient, index) => {
+    const heading = ingredient.group ?? ''
+    const current = groups.at(-1)
+    if (current?.heading === heading) current.items.push({ ingredient, index })
+    else groups.push({ heading, items: [{ ingredient, index }] })
+  })
+
+  return groups
+}

--- a/client/src/routes/create.tsx
+++ b/client/src/routes/create.tsx
@@ -1,28 +1,46 @@
 import { useRef, useState } from 'react'
-import { createFileRoute } from '@tanstack/react-router'
-import { useMutation } from '@tanstack/react-query'
-import { ImageIcon, Loader2, Plus, Trash2, UploadCloud, X } from 'lucide-react'
+import { Link, createFileRoute } from '@tanstack/react-router'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  AlertCircle,
+  ImageIcon,
+  Link2,
+  Loader2,
+  Plus,
+  Trash2,
+  UploadCloud,
+  X,
+} from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { RecipeCard } from '@/components/RecipeCard'
 import type { Recipe } from '@/components/RecipeCard'
-import { apiFetch } from '@/lib/api'
+import { ApiError, apiFetch, apiJson } from '@/lib/api'
 import '@/index.css'
 
 export const Route = createFileRoute('/create')({ component: CreatePage })
 
-type Tab = 'generate' | 'extract'
+type Tab = 'link' | 'generate' | 'extract'
+
+const TAB_LABELS: Record<Tab, string> = {
+  link: 'From link',
+  generate: 'Generate',
+  extract: 'Extract from Images',
+}
 
 function CreatePage() {
-  const [tab, setTab] = useState<Tab>('extract')
+  // Pasting a link is the most common way people acquire a recipe, so it leads.
+  const [tab, setTab] = useState<Tab>('link')
 
   return (
     <div className="min-h-screen bg-cream text-ink">
       <div className="max-w-2xl mx-auto px-4 py-12">
         <h1 className="text-2xl font-bold mb-2">Create Recipe</h1>
-        <p className="text-ink-muted mb-8">Generate or extract recipes with AI</p>
+        <p className="text-ink-muted mb-8">
+          Import a recipe from a link, or make one with AI
+        </p>
 
-        <div className="flex gap-1 p-1 bg-mist rounded-lg mb-8 w-fit">
-          {(['generate', 'extract'] as const).map((t) => (
+        <div className="flex flex-wrap gap-1 p-1 bg-mist rounded-lg mb-8 w-fit">
+          {(['link', 'generate', 'extract'] as const).map((t) => (
             <button
               key={t}
               onClick={() => setTab(t)}
@@ -31,13 +49,170 @@ function CreatePage() {
                   : 'text-ink-muted hover:text-ink-soft'
                 }`}
             >
-              {t === 'generate' ? 'Generate' : 'Extract from Images'}
+              {TAB_LABELS[t]}
             </button>
           ))}
         </div>
 
-        {tab === 'generate' ? <GenerateTab /> : <ExtractTab />}
+        {tab === 'link' && <LinkTab />}
+        {tab === 'generate' && <GenerateTab />}
+        {tab === 'extract' && <ExtractTab />}
       </div>
+    </div>
+  )
+}
+
+type ImportedRecipe = Recipe & { _id: string }
+
+// The two stages the server runs, in order. We can't observe the handover — the
+// request is a single round trip — so the copy advances on a timer sized to a
+// typical scrape. It tells the user what is happening, not when it happened.
+const SORTING_COPY_DELAY_MS = 2500
+
+type ImportPhase = 'reading' | 'sorting'
+
+function importErrorMessage(error: Error): string {
+  if (!(error instanceof ApiError)) {
+    return 'Could not reach Omlete. Check your connection and try again.'
+  }
+
+  switch (error.status) {
+    case 400:
+      return "That link can't be fetched. Check it's a full, public recipe URL."
+    case 404:
+      return "Couldn't find a recipe on that page. Try the recipe's own page rather than a listing or a video."
+    case 502:
+      return "That site didn't respond. It may be down or blocking us — try again in a minute."
+    default:
+      return 'Something went wrong importing that link. Try again.'
+  }
+}
+
+/** A 409 carries the id of the recipe imported from this URL the first time. */
+function alreadyImportedId(error: Error | null): string | null {
+  if (!(error instanceof ApiError) || error.status !== 409) return null
+  const detail = error.detail as { recipe_id?: string } | null
+  return detail?.recipe_id ?? null
+}
+
+function LinkTab() {
+  const queryClient = useQueryClient()
+  const [url, setUrl] = useState('')
+  const [phase, setPhase] = useState<ImportPhase>('reading')
+
+  const { mutate, data, isPending, error, reset } = useMutation<
+    ImportedRecipe,
+    Error,
+    string
+  >({
+    mutationFn: async (target) => {
+      setPhase('reading')
+      const advance = setTimeout(() => setPhase('sorting'), SORTING_COPY_DELAY_MS)
+      try {
+        return await apiJson<ImportedRecipe>('/api/recipes/import-from-url/', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ url: target }),
+        })
+      } finally {
+        clearTimeout(advance)
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['recipes'] })
+    },
+  })
+
+  const trimmed = url.trim()
+  const looksLikeUrl = /^https?:\/\/\S+\.\S+/.test(trimmed)
+  const duplicateId = alreadyImportedId(error)
+
+  const submit = () => {
+    if (!looksLikeUrl || isPending) return
+    mutate(trimmed)
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <label htmlFor="import-url" className="text-sm font-medium text-ink-soft">
+          Paste a recipe link
+        </label>
+        <div className="flex gap-2">
+          <div className="relative flex-1">
+            <Link2 className="size-4 text-ink-faint absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none" />
+            <input
+              id="import-url"
+              type="url"
+              inputMode="url"
+              value={url}
+              onChange={(e) => {
+                setUrl(e.target.value)
+                if (error || data) reset()
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') submit()
+              }}
+              placeholder="https://www.bbcgoodfood.com/recipes/..."
+              disabled={isPending}
+              className="w-full bg-white border border-line rounded-lg pl-9 pr-4 py-3 text-sm text-ink placeholder-ink-faint focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-60"
+            />
+          </div>
+          <Button onClick={submit} disabled={isPending || !looksLikeUrl}>
+            {isPending ? <Loader2 className="animate-spin" /> : 'Import'}
+          </Button>
+        </div>
+        {trimmed !== '' && !looksLikeUrl && (
+          <p className="text-xs text-ink-muted">
+            That doesn't look like a link — it should start with https://
+          </p>
+        )}
+      </div>
+
+      {isPending && (
+        <div className="flex items-center gap-2.5 text-sm text-ink-muted">
+          <Loader2 className="size-4 animate-spin shrink-0" />
+          {phase === 'reading'
+            ? 'Reading the page…'
+            : 'Sorting the ingredients…'}
+        </div>
+      )}
+
+      {duplicateId && (
+        <div className="flex items-start gap-2.5 rounded-lg border border-line bg-white p-4 text-sm">
+          <AlertCircle className="size-4 text-ink-muted shrink-0 mt-0.5" />
+          <div className="space-y-1">
+            <p className="text-ink-soft">You've already imported that link.</p>
+            <Link
+              to="/recipe/$recipeId"
+              params={{ recipeId: duplicateId }}
+              className="text-ink font-medium underline underline-offset-4 hover:text-ink-soft"
+            >
+              Open the recipe
+            </Link>
+          </div>
+        </div>
+      )}
+
+      {error && !duplicateId && (
+        <div className="flex items-start gap-2.5 rounded-lg border border-line bg-white p-4 text-sm">
+          <AlertCircle className="size-4 text-red-500 shrink-0 mt-0.5" />
+          <p className="text-ink-soft">{importErrorMessage(error)}</p>
+        </div>
+      )}
+
+      {data && (
+        <div className="space-y-3">
+          <RecipeCard recipe={data} />
+          <Link
+            to="/recipe/$recipeId"
+            params={{ recipeId: data._id }}
+            className="inline-block text-sm text-ink-soft hover:text-ink underline underline-offset-4"
+          >
+            Open in your recipes
+          </Link>
+        </div>
+      )}
     </div>
   )
 }

--- a/client/src/routes/recipe.$recipeId.tsx
+++ b/client/src/routes/recipe.$recipeId.tsx
@@ -32,7 +32,8 @@ import '@/index.css'
 type IngredientRecipe = {
   name: string
   unit: string
-  amount: number
+  // null when the recipe never gave a quantity — "salt and pepper to taste".
+  amount: number | null
   category: string
   excluded_from_list: boolean
 }
@@ -120,7 +121,10 @@ function RecipeDetailPage() {
           instructions: editInstructions,
           ingredients: editIngredients.map((ing) => ({
             ...ing,
-            amount: parseFloat(ing.amount) || 0,
+            // An empty field means the ingredient has no quantity ("salt, to
+            // taste"), which the API stores as null. Coercing it to 0 here
+            // would overwrite that with a number nobody typed.
+            amount: ing.amount.trim() === '' ? null : parseFloat(ing.amount) || 0,
           })),
         }),
       })
@@ -165,7 +169,10 @@ function RecipeDetailPage() {
     setEditTitle(recipe.title)
     setEditInstructions([...recipe.instructions])
     setEditIngredients(
-      recipe.ingredients.map((i) => ({ ...i, amount: String(i.amount) }))
+      recipe.ingredients.map((i) => ({
+        ...i,
+        amount: i.amount == null ? '' : String(i.amount),
+      }))
     )
     setEditing(true)
   }
@@ -376,7 +383,7 @@ function RecipeDetailPage() {
                       >
                         <span className="flex-1">{ing.name}</span>
                         <span className="text-ink font-medium shrink-0">
-                          {ing.amount} {ing.unit}
+                          {ing.amount == null ? ing.unit : `${ing.amount} ${ing.unit}`}
                         </span>
                         <button
                           onClick={() =>

--- a/client/src/routes/recipe.$recipeId.tsx
+++ b/client/src/routes/recipe.$recipeId.tsx
@@ -25,6 +25,8 @@ import {
 } from '@/components/ui/select'
 import { apiFetch } from '@/lib/api'
 import { StarRating } from '@/components/StarRating'
+import { RecipeHeroImage, RecipeMetaRow } from '@/components/RecipeMetaRow'
+import { groupIngredients } from '@/lib/groupIngredients'
 import type { Recipe } from '@/components/RecipeCard'
 import { useWakeLock } from '@/hooks/useWakeLock'
 import '@/index.css'
@@ -34,6 +36,10 @@ type IngredientRecipe = {
   unit: string
   // null when the recipe never gave a quantity — "salt and pepper to taste".
   amount: number | null
+  // Both set only by a URL import: preparation stripped off the name, and the
+  // heading the line sat under on the source page.
+  note?: string | null
+  group?: string | null
   category: string
   excluded_from_list: boolean
 }
@@ -48,6 +54,8 @@ type RecipeDetail = Omit<Recipe, 'ingredients'> & {
   created_at: string
   ingredients: IngredientRecipe[]
 }
+// `Recipe` already carries the import metadata (image_url, times, servings,
+// source), so RecipeDetail inherits it.
 
 type CategoryConfig = {
   name: string
@@ -240,6 +248,14 @@ function RecipeDetailPage() {
 
         {recipe && (
           <div className="bg-white border border-line rounded-xl p-6 space-y-5 shadow-sm">
+            {recipe.image_url && !editing && (
+              <RecipeHeroImage
+                src={recipe.image_url}
+                alt={recipe.title}
+                className="h-56 sm:h-72 rounded-lg"
+              />
+            )}
+
             {/* Title */}
             {editing ? (
               <Input
@@ -250,6 +266,9 @@ function RecipeDetailPage() {
             ) : (
               <h2 className="text-xl font-semibold text-ink">{recipe.title}</h2>
             )}
+
+            {/* Times, servings and attribution — imported recipes only */}
+            {!editing && <RecipeMetaRow recipe={recipe} />}
 
             {/* Date + Rating */}
             <div className="flex items-center justify-between">
@@ -373,37 +392,55 @@ function RecipeDetailPage() {
                     </Button>
                   </div>
                 ) : (
-                  <ul className="space-y-1.5">
-                    {recipe.ingredients.map((ing, i) => (
-                      <li
-                        key={i}
-                        className={`text-sm flex items-center gap-2 ${
-                          ing.excluded_from_list ? 'opacity-40' : 'text-ink-soft'
-                        }`}
-                      >
-                        <span className="flex-1">{ing.name}</span>
-                        <span className="text-ink font-medium shrink-0">
-                          {ing.amount == null ? ing.unit : `${ing.amount} ${ing.unit}`}
-                        </span>
-                        <button
-                          onClick={() =>
-                            toggleExclude.mutate({
-                              index: i,
-                              excluded: !ing.excluded_from_list,
-                            })
-                          }
-                          className="shrink-0 text-ink-faint hover:text-ink-muted transition-colors cursor-pointer"
-                          title={ing.excluded_from_list ? 'Include in shopping list' : 'Exclude from shopping list'}
-                        >
-                          {ing.excluded_from_list ? (
-                            <EyeOff className="size-3.5" />
-                          ) : (
-                            <Eye className="size-3.5" />
-                          )}
-                        </button>
-                      </li>
+                  <div className="space-y-4">
+                    {groupIngredients(recipe.ingredients).map((group) => (
+                      <div key={group.heading || 'ungrouped'}>
+                        {group.heading && (
+                          <h4 className="text-xs font-medium text-ink-soft mb-2">
+                            {group.heading}
+                          </h4>
+                        )}
+                        <ul className="space-y-1.5">
+                          {group.items.map(({ ingredient: ing, index }) => (
+                            <li
+                              key={index}
+                              className={`text-sm flex items-center gap-2 ${
+                                ing.excluded_from_list ? 'opacity-40' : 'text-ink-soft'
+                              }`}
+                            >
+                              <span className="flex-1">
+                                {ing.name}
+                                {ing.note && (
+                                  <span className="text-ink-faint">, {ing.note}</span>
+                                )}
+                              </span>
+                              <span className="text-ink font-medium shrink-0">
+                                {ing.amount == null
+                                  ? ing.unit
+                                  : `${ing.amount} ${ing.unit}`}
+                              </span>
+                              <button
+                                onClick={() =>
+                                  toggleExclude.mutate({
+                                    index,
+                                    excluded: !ing.excluded_from_list,
+                                  })
+                                }
+                                className="shrink-0 text-ink-faint hover:text-ink-muted transition-colors cursor-pointer"
+                                title={ing.excluded_from_list ? 'Include in shopping list' : 'Exclude from shopping list'}
+                              >
+                                {ing.excluded_from_list ? (
+                                  <EyeOff className="size-3.5" />
+                                ) : (
+                                  <Eye className="size-3.5" />
+                                )}
+                              </button>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
                     ))}
-                  </ul>
+                  </div>
                 )}
               </div>
 

--- a/client/src/routes/recipes.tsx
+++ b/client/src/routes/recipes.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { LayoutGrid, List, Loader2 } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
 import { StarRating } from '@/components/StarRating'
+import { RecipeHeroImage, formatMinutes } from '@/components/RecipeMetaRow'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import '@/index.css'
@@ -14,6 +15,11 @@ type RecipeSummary = {
   ingredient_count: number
   rating: number | null
   created_at: string | null
+  // Set only on imported recipes.
+  image_url: string | null
+  total_minutes: number | null
+  servings: number | null
+  source_name: string | null
 }
 
 type ViewMode = 'list' | 'grid'
@@ -150,11 +156,23 @@ function RecipeList() {
 
 function RecipeMeta({ recipe }: { recipe: RecipeSummary }) {
   return (
-    <div className="flex items-center gap-3 mt-1.5 text-sm text-ink-muted">
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1.5 text-sm text-ink-muted">
       <span>
         {recipe.ingredient_count} ingredient
         {recipe.ingredient_count !== 1 ? 's' : ''}
       </span>
+      {recipe.total_minutes != null && (
+        <>
+          <span className="text-ink-subtle">·</span>
+          <span>{formatMinutes(recipe.total_minutes)}</span>
+        </>
+      )}
+      {recipe.source_name && (
+        <>
+          <span className="text-ink-subtle">·</span>
+          <span className="truncate max-w-[12rem]">{recipe.source_name}</span>
+        </>
+      )}
       <span className="text-ink-subtle">·</span>
       <span>
         {recipe.created_at
@@ -173,6 +191,13 @@ type RecipeItemProps = {
 function RecipeListRow({ recipe, onRate }: RecipeItemProps) {
   return (
     <div className="bg-white border border-line rounded-xl p-5 flex items-center gap-4 shadow-sm">
+      {recipe.image_url && (
+        <RecipeHeroImage
+          src={recipe.image_url}
+          alt={recipe.title}
+          className="size-16 rounded-lg shrink-0"
+        />
+      )}
       <div className="flex-1 min-w-0">
         <Link
           to="/recipe/$recipeId"
@@ -193,21 +218,30 @@ function RecipeListRow({ recipe, onRate }: RecipeItemProps) {
 
 function RecipeGridCard({ recipe, onRate }: RecipeItemProps) {
   return (
-    <div className="bg-white border border-line rounded-xl p-5 flex flex-col gap-4 h-full shadow-sm">
-      <div className="flex-1 min-w-0">
-        <Link
-          to="/recipe/$recipeId"
-          params={{ recipeId: recipe.id }}
-          className="text-ink font-medium hover:underline underline-offset-4"
-        >
-          {recipe.title}
-        </Link>
-        <RecipeMeta recipe={recipe} />
+    <div className="bg-white border border-line rounded-xl overflow-hidden flex flex-col h-full shadow-sm">
+      {recipe.image_url && (
+        <RecipeHeroImage
+          src={recipe.image_url}
+          alt={recipe.title}
+          className="h-36"
+        />
+      )}
+      <div className="p-5 flex flex-col gap-4 flex-1">
+        <div className="flex-1 min-w-0">
+          <Link
+            to="/recipe/$recipeId"
+            params={{ recipeId: recipe.id }}
+            className="text-ink font-medium hover:underline underline-offset-4"
+          >
+            {recipe.title}
+          </Link>
+          <RecipeMeta recipe={recipe} />
+        </div>
+        <StarRating
+          value={recipe.rating}
+          onChange={(rating) => onRate(recipe.id, rating)}
+        />
       </div>
-      <StarRating
-        value={recipe.rating}
-        onChange={(rating) => onRate(recipe.id, rating)}
-      />
     </div>
   )
 }

--- a/docs/GAP_ANALYSIS.md
+++ b/docs/GAP_ANALYSIS.md
@@ -1,0 +1,291 @@
+# Omlete — Codebase Audit & Competitive Gap Analysis
+
+_July 2026. Based on `main` @ `9ec7077`._
+
+---
+
+## 1. What Omlete actually is today
+
+Stripped of the marketing, Omlete is **a shopping-list app with an AI recipe importer attached**. That's a real product, and the shopping-list half is genuinely good. But it is not, today, a recipe manager — and the README/CLAUDE.md describe an app that doesn't exist (they still reference Render, a `/meal-plan` route, and `POST /meal-plan/shopping-list/`, none of which are in the codebase).
+
+### What's genuinely strong
+
+| Thing | Why it's good |
+|---|---|
+| **Ingredient canonicalisation via embeddings** (`ingredient_service.py`, `tools.py`) | Voyage-4 2048-dim embeddings + Mongo `$vectorSearch` at ≥0.9, exposed to Claude as a tool so the model reconciles "spring onions" against your existing library at generation time. **Nobody in the competitive set does this.** This is the most interesting thing in the repo. |
+| **Shopping list source tracking** (`ItemSource`, `main.py:519-595`) | Items remember which recipes contributed which amounts, so removing a recipe subtracts exactly its share and drops the item only when nothing else needs it. Paprika and AnyList do *not* do this cleanly — they merge and forget. |
+| **Plan vs Shop modes** (`list.$listId.tsx:389-406`) | Same data, two layouts, sensible default. Genuinely thoughtful. |
+| **Optimistic mutations + drag reorder** | The list page is the most polished surface in the app. |
+| **Multi-photo → single recipe extraction** | Handles the real case of a cookbook spread across two pages. Most competitors treat each photo as one recipe. |
+| **Editable categories with custom aisle order** | Matches AnyList/Tandoor. Table stakes, and you have it. |
+
+### The data model, in full
+
+```python
+Recipe   = title + instructions[]                       # lib/types.py:33
+Ingredient = name + unit + amount + category + excluded_from_list
+RecipeDocument = Recipe + ingredients[] + rating + created_at
+```
+
+**That's it.** No servings, no prep/cook time, no photo, no source URL, no tags, no cuisine, no notes, no nutrition, no difficulty, no yield. Verified: `grep -riE "servings|prep_time|cook_time|tags|image_url|source_url|nutrition|calories"` returns **zero hits** across `server/` and `client/src/`.
+
+Every gap below flows from that one line.
+
+---
+
+## 2. The competitive landscape
+
+Three cohorts, and Omlete is currently competitive with none of them.
+
+**Cohort A — Classic managers.** [Paprika](https://www.paprikaapp.com/) (URL import, pantry with expiry tracking, daily/weekly/monthly meal planner, reusable menus, scaling + unit conversion, cook mode, cross-device sync), [Mela](https://mela.recipes/) (Apple-only, structured-data import only), [AnyList](https://www.anylist.com/) (real-time shared household lists, aisle ordering, item photos, running price total, recipe import, meal-plan calendar — $9.99/yr). Paprika hasn't shipped a major feature since 2018; the category is stagnant and beatable.
+
+**Cohort B — Self-hosted.** [Mealie and Tandoor](https://cooklang.org/blog/42-tandoor-vs-mealie-vs-kitchenowl/) — both do URL scraping. Tandoor adds OCR for cookbooks, keyword/tag systems, full-text search, iCal meal-plan export, OpenFoodFacts nutrition, barcode scanning, aisle mapping, and meal-cost calculation. This is the closest architectural comparator to what you've built, and Tandoor is well ahead on feature surface.
+
+**Cohort C — AI-native (2024-2026 wave).** ReciMe, Pluck, Recipe Bro, FoodiePrep, Nutrola, CookNest. Their entire pitch is **import from anywhere** — [any website, Instagram, TikTok, YouTube, Pinterest, screenshots](https://recipebro.com/import) — plus auto-derived nutrition and an agentic assistant. [Nutrola](https://nutrola.app/en/blog/best-apps-that-extract-recipes-from-video-urls-2026) pulls full ingredient lists with quantities out of TikTok/Reels/Shorts. This is the cohort Omlete is actually in, and it's the cohort moving fastest.
+
+Separately: [SuperCook](https://apps.apple.com/us/app/supercook-ai-meals-scanner/id6743327665) owns "what can I make with what I have" — a pantry of 2000+ ingredients matched against 11M recipes. That's the closest thing to Omlete's original stated premise ("turn leftover ingredients into a recipe"), and Omlete has **no pantry at all**.
+
+### Feature matrix
+
+| | Omlete | Paprika | AnyList | Tandoor | AI-native cohort |
+|---|:--:|:--:|:--:|:--:|:--:|
+| Import from URL | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Import from photo / OCR | ✅ | ❌ | ❌ | ✅ | ✅ |
+| Import from video / social | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Generate recipe from ingredients | ✅ | ❌ | ❌ | ❌ | ✅ |
+| Recipe photos | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Search / tags / filter | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Servings + scaling | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Prep/cook times | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Meal-plan calendar | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Pantry | ❌ | ✅ | ❌ | ✅ | partial |
+| Cook mode (step tracking, timers) | wake lock only | ✅ | ❌ | ✅ | ✅ |
+| Nutrition | ❌ | ❌ | ❌ | ✅ | ✅ |
+| Shared / household lists | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Offline | ❌ | ✅ | ✅ | ❌ | partial |
+| Aisle-ordered lists | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Ingredient-level dedup across recipes | ✅✅ | partial | partial | partial | ❌ |
+| Semantic ingredient matching | ✅✅ | ❌ | ❌ | ❌ | ❌ |
+
+Two columns where you're **ahead of the entire field**. Ten where you're behind all of it.
+
+---
+
+## 3. The biggest gaps, ranked
+
+### 🔴 Gap 1 — No URL import
+
+**The single highest-leverage missing feature.** Every app in every cohort has it. It is how normal people acquire recipes: they find a link, they paste it. Omlete's only two inputs are "type your ingredients" and "photograph a cookbook" — both are high-effort, low-frequency paths.
+
+The implementation is cheap because you already have every piece:
+
+1. `pip install recipe-scrapers` — [649 supported sites](https://docs.recipe-scrapers.com/), parses JSON-LD, Microdata, RDFa and OpenGraph.
+2. On a hit, you get title, ingredients, instructions, image, times, yield, nutrition — **for free**, no LLM call, no token cost, sub-second.
+3. On a miss, fall back to your existing Claude path with the page text.
+4. Either way, run the result through `find_similar_ingredients` so the ingredients land canonicalised. That's your differentiator applied to the industry-standard input.
+
+You'd match Paprika/Mealie on import in a day or two, and beat them on the ingredient reconciliation.
+
+**Then extend to social video** (yt-dlp → transcript + keyframes → Claude). That's where the AI-native cohort is competing right now and it plays directly to a Claude-backed backend.
+
+### 🔴 Gap 2 — No recipe photos
+
+A recipe library with no images is a text list. This is why `/recipes` grid view (`recipes.tsx:135-145`) looks identical to list view — there's nothing to put in the grid. Users pick what to cook by looking at food.
+
+Note the irony: you upload photos to *create* recipes and then throw them away. `_extract_and_save` (`main.py:176-204`) base64s the image, sends it to Claude, and discards it. Storing that image (or the first one) as the recipe's hero image is nearly free.
+
+### 🔴 Gap 3 — No search, no tags, no filtering
+
+`GET /recipes/` is `RecipeDocument.find_all()` (`main.py:242`) — every recipe, every time, unpaginated, unsorted beyond `created_at`, rendered as a flat list. This is fine at 20 recipes. At 100 it's unusable, at 500 it's a several-hundred-KB payload on every page load of `/recipes`, `/list/$listId`, and the suggest sheet.
+
+You need, in order: text search on title+ingredients (Mongo text index or Atlas Search — you already pay for Atlas), tags/cuisine/meal-type, filter by rating, and pagination. Without this the library is write-only.
+
+### 🟠 Gap 4 — No servings, and therefore no scaling
+
+`Recipe` has no `servings` field, so "scale to 6 people" is impossible, and the shopping-list amounts are meaningless in absolute terms — a recipe adds "500g pasta" with no statement of how many people that feeds. Paprika markets scaling + unit conversion as a headline feature.
+
+This also silently corrupts the list: `add_recipe_to_list` sums raw amounts across recipes with no notion of yield.
+
+### 🟠 Gap 5 — No times or metadata
+
+No prep time, no cook time, no total time, no difficulty. "Quick & easy" exists as a *suggestion filter* (`DIET_OPTIONS`/`EASE_OPTIONS`, `list.$listId.tsx:837-849`) but is never persisted to the recipe, so you can't filter your own library by it. The information is in the model's head at generation time and you're discarding it.
+
+### 🟠 Gap 6 — No meal-plan calendar
+
+Every competitor has one. Your `ListDocument` is *nearly* a meal plan — it has recipes and a date-derived name (`_auto_list_name()`, `main.py:354-357`) — but there's no day assignment, so "Tuesday: chilli" isn't expressible. This is the smallest gap-to-value ratio on the list: add `day` to the list↔recipe relation and you have a week planner.
+
+### 🟠 Gap 7 — No cook mode
+
+You have `useWakeLock` (good, that's the annoying part) but nothing else. Paprika's cook mode: cross off ingredients as you use them, highlight the current step, timers. Yours renders a static `<ol>`. `highlightAmounts.tsx` is a nice touch that's begging to be wired to a step-by-step view with a "start timer" affordance when a step mentions a duration.
+
+### 🟡 Gap 8 — No pantry
+
+The app's origin story is "turn leftover ingredients into a recipe" and there's no representation of what you have. SuperCook's whole business is this. You have the best ingredient vocabulary of anyone (embedded, canonicalised, scored) and no place to say "I own these."
+
+Pantry also closes the loop on the shopping list: check something off → it's in the pantry → next list omits it.
+
+### 🟡 Gap 9 — No auth, no users, no sharing
+
+There is **zero authentication anywhere in the codebase** (verified — no `Depends`, no tokens, no sessions). Consequences:
+
+- Every deployed instance is single-tenant-by-accident: one global recipe pool, one global list pool, one `UserSettingsDocument` (`_get_or_create_settings` does `find_one()` with no filter, `main.py:450-455`).
+- **Household sharing — AnyList's entire value proposition — is unbuildable** without this.
+- See §4; it's also a live cost and abuse problem.
+
+### 🟡 Gap 10 — No offline
+
+`manifest.webmanifest` exists but there is **no service worker** (verified: no `serviceWorker`, no `vite-plugin-pwa`, no `workbox`). So the PWA installs and then shows a blank screen in a supermarket basement with no signal. That's the exact moment the app is most needed. The manifest also still has `background_color`/`theme_color` of `#0f172a` — dark slate, from before the retheme.
+
+---
+
+## 4. Engineering risks that will bite before any of that
+
+These aren't features; they're things that break.
+
+### 🔴 Unauthenticated LLM endpoints = an open wallet
+
+`POST /api/recipes/generate/` and `POST /api/recipes/extract-from-images/` invoke **Claude Opus 4.5** with no auth, no rate limit, no quota, no per-IP throttle. Anyone who finds the Railway URL can run your Anthropic bill up indefinitely, and the image endpoint reads uploads fully into memory (`await file.read()`, `main.py:179`) with no size cap — a large multipart POST is also a straightforward OOM.
+
+CORS (`main.py:59-65`) allows `https://.*\.up\.railway\.app`, which is a wildcard over every app on Railway — but that's moot, because with no auth the API is equally callable by curl.
+
+**Fix before anything else:** an API key or session check on the two Claude endpoints, `slowapi` rate limiting, and a `MAX_UPLOAD_BYTES` guard.
+
+### 🔴 Zero database indexes
+
+No `Indexed()` fields, no `Settings.indexes` on any of the four documents. Concretely:
+
+- `/categorize` (`main.py:476-484`) runs `find_one({"name": {"$regex": "^…$", "$options": "i"}})` against the ingredients collection — an **unanchored-in-practice regex collection scan on every quick-add**, over a collection with 2048-float embeddings in every document. This is the slowest query in the app and it runs on the most latency-sensitive interaction.
+- `IngredientDocument.name` has no unique index, and `_save_recipe` inserts new ingredients with no dedupe check. Two recipes generated in parallel both marking "shallots" as new both insert it. Your canonical ingredient vocabulary drifts.
+
+**Fix:** unique index on lowercased `name`; index `RecipeDocument.created_at`; store a lowercase `name_key` and query on equality instead of regex.
+
+### 🟠 N+1 on the lists page
+
+`GET /lists/` (`main.py:360-378`) loops over every list and issues a separate `RecipeDocument.find(In(...))` per list. Ten lists = eleven round trips on your home screen. Collect all recipe ids, one query, map in memory.
+
+### 🟠 The frontend has no error handling
+
+**No toast, no error banner, no `isError` branch anywhere** in `client/src`. The three `onError` handlers in `list.$listId.tsx` are optimistic-rollback only — they restore state silently and tell the user nothing. Worse, `create.tsx:147-149`:
+
+```ts
+} catch {
+  // Continue with next group on error
+}
+```
+
+A failed extraction is **completely silent** — the spinner advances, the recipe never appears, no explanation. Add `sonner` and surface failures. This is a 30-minute fix with an outsized effect on how the app *feels*.
+
+### 🟠 Long blocking requests with no progress
+
+`runner.until_done()` consumes the stream server-side and returns one JSON blob. A generate is 20-60s of a spinner. Then `handleAddSelected` (`list.$listId.tsx:899-935`) generates selected meals **sequentially** — pick 5 suggestions and you wait 2-5 minutes with a `done/total` counter and no cancel. No client timeout, no retry, no partial results.
+
+Consider SSE with incremental recipe fields, or a job + poll pattern. Also: `suggest_meals` and `categorize` don't need Opus-class reasoning — `suggest_meals` uses Opus 4.5 for five one-line meal ideas (`main.py:166-171`). Move it to Haiku and cut that call's cost by ~95%.
+
+### 🟠 The shopping list merge ignores your best asset
+
+`add_recipe_to_list` (`main.py:540-543`) merges items on `item.name.lower() == ing.name.lower() and item.unit == ing.unit`. Exact string, exact unit. So:
+
+- "spring onions" and "scallions" → two lines
+- "500 g flour" and "2 cups flour" → two lines
+- "garlic clove" and "garlic cloves" → two lines
+
+**You have a semantic ingredient matcher and a vector index sitting right there and you're using `==` on the shopping list.** Fixing this is the clearest expression of your differentiator and it's mostly plumbing you've already written. Pair it with a unit-conversion table (g↔kg, ml↔l, tsp↔tbsp↔cup) and the list gets visibly smarter than Paprika's.
+
+### 🟡 The retheme is half-finished
+
+The `a00628e` cream+amber retheme missed the "Suggest meals" sheet, which is still **entirely on the old dark theme** — `bg-slate-900 border-slate-700 text-white`, `text-emerald-400`, `bg-slate-800` inputs (`list.$listId.tsx:961-1055`). Opening it from a cream page is jarring. Plus scattered leftovers: `border-slate-700` on the Delete button (`recipe.$recipeId.tsx:207`), `text-slate-500 hover:text-red-400` in six files, `border-b border-slate-700/50` (`list.$listId.tsx:706`), and `StarRating` unfilled stars at `text-slate-500` against cream.
+
+### 🟡 Test coverage is ~2% and there's no CI
+
+One backend test file (`tests/test_ingredient_service.py`, 104 lines, covering only `find_similar`). **Zero tests on any of the 25 API endpoints.** Vitest is configured and there are **zero frontend test files**. No `.github/` directory at all — nothing runs on push.
+
+The riskiest untested logic is the list arithmetic: `add_recipe_to_list`/`remove_recipe_from_list` do read-modify-write amount summing across sources, and `reorder_items` has genuinely subtle slot-preservation logic (`main.py:618-639`) mirrored by hand in TypeScript (`list.$listId.tsx:104-116`). Two implementations of the same algorithm in two languages, neither tested.
+
+### 🟡 Docs describe a different app
+
+`README.md` and `CLAUDE.md` both claim Render deployment (you moved to Railway in `71d4f1e`), a `/meal-plan` page, and `POST /meal-plan/suggest/` + `POST /meal-plan/shopping-list/` endpoints. None exist. Anyone onboarding — human or agent — starts from a false map.
+
+---
+
+## 5. Where Omlete can actually win
+
+Don't try to out-feature Paprika. Pick the thing nobody else has and push it hard.
+
+**The semantic ingredient graph is the moat.** Every competitor treats ingredients as strings. You treat them as embedded entities with a canonical vocabulary that grows as you cook. Things that unlocks, roughly in order of effort:
+
+1. **Semantic list merging** (§4) — immediate, visible, uses code you've already written.
+2. **Pantry with fuzzy matching** — "I have scallions" satisfies a recipe calling for spring onions. SuperCook can't do this; they use a fixed 2000-item taxonomy.
+3. **"What can I make?"** — vector-match pantry contents against your recipe library, rank by coverage, show "you're 2 ingredients away from X." This is the app's original premise, finally delivered.
+4. **Substitutions** — "no crème fraîche" → nearest neighbours in embedding space, filtered by what's in the pantry.
+5. **Waste-driven suggestions** — items that have sat unchecked on lists, or pantry items by age, feed into `suggest_meals` as a bias. That's a real, defensible reason to open the app on a Tuesday.
+
+None of these are buildable without the boring work in §3 and §4 first. But they're the reason to do that work.
+
+---
+
+## 6. Recommended sequence
+
+**Phase 0 — Stop the bleeding (days)**
+- Auth on the Claude endpoints + rate limiting + upload size cap
+- Database indexes (unique lowercase ingredient name; `created_at`)
+- Error toasts on the frontend
+- Fix the N+1 in `GET /lists/`
+- Move `suggest_meals` and `categorize` off Opus
+- Update README/CLAUDE.md to match reality
+- A GitHub Actions workflow running pytest + vitest + lint
+
+**Phase 1 — Become a recipe manager (2-3 weeks)**
+- **URL import** via `recipe-scrapers` with Claude fallback ← *the big one*
+- Extend `Recipe`: `servings`, `prep_minutes`, `cook_minutes`, `tags[]`, `image_url`, `source_url`, `notes`
+- Persist the extraction photo as the hero image
+- Search + tag filter + pagination on `/recipes`
+- Backfill: one-off script to have Claude infer the new fields for existing recipes
+
+**Phase 2 — Cooking and planning (2-3 weeks)**
+- Servings + scaling (recompute amounts, scale list contributions)
+- Cook mode: step tracking, ingredient check-off, timers from step text
+- Meal-plan calendar (day assignment on the existing list↔recipe relation)
+- Service worker for offline list access
+
+**Phase 3 — The moat (ongoing)**
+- Semantic + unit-aware list merging
+- Pantry
+- "What can I make?" / substitutions / waste-driven suggestions
+- Social-video import
+- Multi-user + household sharing (needs Phase 0 auth as its foundation)
+
+---
+
+## Appendix — file reference
+
+| Finding | Location |
+|---|---|
+| Recipe model missing all metadata | `server/lib/types.py:33-39` |
+| No indexes on any document | `server/data_models/__init__.py:11-77` |
+| CORS wildcard over Railway | `server/main.py:59-65` |
+| Unauthenticated Opus endpoint | `server/main.py:115-135` |
+| Opus used for one-line suggestions | `server/main.py:166-171` |
+| Uncapped in-memory image read | `server/main.py:179` |
+| Unpaginated `find_all()` | `server/main.py:242` |
+| N+1 on lists | `server/main.py:360-378` |
+| Regex collection scan on categorize | `server/main.py:476-484` |
+| Exact-string list merge | `server/main.py:540-543` |
+| Untested reorder slot logic (Python) | `server/main.py:618-639` |
+| Untested reorder slot logic (TS mirror) | `client/src/routes/list.$listId.tsx:104-116` |
+| Silently swallowed extraction errors | `client/src/routes/create.tsx:147-149` |
+| Dark-theme "Suggest meals" sheet | `client/src/routes/list.$listId.tsx:961-1055` |
+| Stale dark theme colours in manifest | `client/public/manifest.webmanifest` |
+
+## Sources
+
+- [Paprika Recipe Manager](https://www.paprikaapp.com/)
+- [AnyList](https://www.anylist.com/)
+- [Best Recipe Management Software 2026 — Cooklang](https://cooklang.org/blog/48-best-recipe-management-software/)
+- [Tandoor vs Mealie vs KitchenOwl — Cooklang](https://cooklang.org/blog/42-tandoor-vs-mealie-vs-kitchenowl/)
+- [recipe-scrapers documentation](https://docs.recipe-scrapers.com/)
+- [Recipe structured data — Google Search Central](https://developers.google.com/search/docs/appearance/structured-data/recipe)
+- [schema.org/Recipe](https://schema.org/Recipe)
+- [Recipe Bro — import from web and social](https://recipebro.com/import)
+- [Best apps that extract recipes from video URLs 2026 — Nutrola](https://nutrola.app/en/blog/best-apps-that-extract-recipes-from-video-urls-2026)
+- [SuperCook](https://apps.apple.com/us/app/supercook-ai-meals-scanner/id6743327665)
+- [Instacart Developer Platform — shopping list page](https://docs.instacart.com/developer_platform_api/guide/concepts/shopping_list/)

--- a/docs/PRD_URL_IMPORT.md
+++ b/docs/PRD_URL_IMPORT.md
@@ -259,19 +259,24 @@ Index `source_url` and return 409 with the existing recipe id on re-import. Requ
 - The Opus fallback is told to return an empty recipe for a page that has none, which is what turns into the 404. Without that it will always oblige with something.
 - **Not done, still required before this is public:** rate limiting (open question 4). The endpoint makes the server fetch arbitrary URLs and then spends tokens on the result, with no authentication in front of it.
 
-### Step 6 — Frontend
+### Step 6 — Frontend ✅ done
 - New `LinkTab` in `client/src/routes/create.tsx`, made the default
 - Two-phase progress copy ("Reading the page…" → "Sorting the ingredients…")
 - **Real error handling** — this is the first feature that genuinely needs it, and it's a #50 P0 item
 - Surface `image_url`, times and servings on `RecipeCard` and the recipe detail page
+- Error handling landed as `apiJson()` in `lib/api.ts`, alongside the existing `apiFetch`. `fetch` only rejects on a network failure, so every current caller renders a 502's body as though it were a recipe. `apiJson` throws an `ApiError` carrying the status and FastAPI's `detail`; the 409 branch reads `recipe_id` out of it and offers a link to the existing recipe. Migrating the other call sites is left alone deliberately — it changes behaviour well outside this feature.
+- The two-phase copy advances on a **timer**, not on observed progress. The import is a single round trip, so the client cannot see the handover from scrape to structure. The stages do happen in that order; the timing is a guess.
+- Ingredient `note` and `group` are shown on both the card and the detail page. Grouping goes through `lib/groupIngredients.ts`, which carries the original array index along — the detail page's exclude-from-list toggle addresses ingredients by position, and regrouping must not renumber them.
 
-### Step 7 — Share target
+### Step 7 — Share target — **not done**
 - `share_target` in `manifest.webmanifest`
 - `/create` reads `?url=` on mount and pre-fills
 - Test on Android Chrome — iOS does not support Web Share Target
+- The link tab this depends on now exists, so this is the next thing to pick up.
 
-### Step 8 — Docs
+### Step 8 — Docs — partly done
 - Update `README.md` / `CLAUDE.md` (both currently describe endpoints that don't exist)
+- `CLAUDE.md`'s backend section now matches reality. `README.md` has not been touched.
 
 **Suggested sequencing:** steps 1-2 are self-contained and testable with zero network and zero tokens — worth doing first and merging on their own. Steps 3-5 are the backend spine. Steps 6-7 are frontend. Step 4 (model changes) unblocks other #50 work, so pulling it earlier is reasonable.
 

--- a/docs/PRD_URL_IMPORT.md
+++ b/docs/PRD_URL_IMPORT.md
@@ -126,12 +126,14 @@ async def fetch_page(url: str) -> str        # SSRF-guarded async fetch
 def scrape(html: str, url: str) -> ScrapedRecipe | None   # wild_mode=True
 ```
 
-**SSRF guard — required, not optional.** This endpoint takes a user-supplied URL and makes the server fetch it. Without a guard it's a hole straight into the internal network. Must:
+**SSRF guard — required, not optional.** This endpoint takes a user-supplied URL and makes the server fetch it, then returns the parsed result to the caller. That is a textbook full-read SSRF primitive. See [Appendix A](#appendix-a--ssrf-in-detail) for the full threat model, why the obvious mitigations fail, and a reference implementation.
 
-- Allow only `http`/`https` schemes
-- Resolve the hostname and **reject private/reserved ranges**: `127.0.0.0/8`, `10/8`, `172.16/12`, `192.168/16`, `169.254/16` (cloud metadata — `169.254.169.254` is the one that matters), `::1`, unique-local v6
-- Re-check after **every redirect**, cap redirects at ~5
-- Cap response size (~2 MB) and timeout (~10s)
+Summary of what the guard must do:
+
+- Allow only `http` / `https` schemes
+- Resolve the hostname and reject **every** returned address that is loopback, private, link-local, reserved, multicast or unspecified — checked with `ipaddress`, not string matching
+- Disable automatic redirects and **re-validate every hop**, capped at ~5
+- Cap response size (~2 MB, enforced while streaming) and total timeout (~10s)
 - Send a real User-Agent; many sites 403 a default `python-httpx`
 
 `httpx==0.28.1` is already in `requirements.txt`, so use `httpx.AsyncClient` rather than `scrape_me()` — the latter fetches synchronously and would block the event loop.
@@ -209,7 +211,7 @@ Index `source_url` and return 409 with the existing recipe id on re-import. Requ
 | Import the site's rating? | **No** | It's the crowd's rating, not the user's. Our `rating` field means "did *I* like it" |
 | Import nutrition? | **No, not yet** | Returns unparsed strings; out of scope per #50 |
 | Hero image | Store the URL, don't re-host | Cheap. Hotlinks can rot — re-hosting is a later improvement |
-| Save directly or preview first? | **Preview, then save** | See open question 1 — recommended but costs an extra step |
+| Save directly or preview first? | **Save immediately** | Consistent with the existing generate and extract flows. Recipes are editable and deletable, so a bad import is cheap to fix |
 | Default Create tab | From link | Will be the most-used path |
 | robots.txt | Ignore, but always store `source_url` | User is importing a page they're already viewing; attribution is the right etiquette |
 
@@ -280,7 +282,162 @@ Index `source_url` and return 409 with the existing recipe id on re-import. Requ
 
 ## Open questions
 
-1. **Preview before save, or save immediately?** The existing extract flow saves immediately. Preview is better UX — Paprika does it, and it stops bad imports polluting the library — but it's an extra screen and an extra state. *Recommendation: preview.* Import quality varies too much across sites to save blind.
+1. ~~**Preview before save, or save immediately?**~~ **Resolved: save immediately**, matching the existing generate and extract flows. Imports land straight in the library; the user edits or deletes if the import was poor.
 2. **What do we do about `amount` on unquantified ingredients?** `IngredientRecipe.amount` is currently a **required `float`**, so "salt and pepper to taste" has no honest representation and the model presumably invents one. This is a pre-existing wart that URL import will hit constantly. *Recommendation: make `amount` `Optional[float]`* — but it touches the list-merge arithmetic at `main.py:540-557`, so it needs its own care.
 3. **Video links?** Pasting an Instagram or TikTok URL will fail with `NoSchemaFoundInWildMode`. Do we detect those hosts and show "video import isn't supported yet", or let it fall through to the generic error? A clear message is cheap and this *will* happen.
 4. **Rate limiting.** This endpoint makes the server fetch arbitrary URLs. Even with the SSRF guard it's an abuse vector for traffic amplification. Needs the #50 P0 rate-limiting work — arguably a hard dependency rather than a nice-to-have.
+
+---
+
+## Appendix A — SSRF in detail
+
+### What the vulnerability is
+
+Server-Side Request Forgery: the client supplies a URL and the **server** makes the request. The attacker doesn't get to reach the destination themselves — they borrow our server's network position to do it.
+
+That matters because our server sits *inside* a trust boundary the attacker is outside of. It can reach the container's loopback interface, Railway's private network, and whatever the platform exposes on link-local addresses. A browser on the open internet can reach none of those.
+
+`POST /api/recipes/import-from-url/` is close to the worst-case shape:
+
+- **The attacker fully controls the destination** — that's the entire feature
+- **The response comes back to them.** We parse the fetched page and return the result. That makes it a **full-read** SSRF rather than a blind one. Blind SSRF leaks timing; full-read leaks content.
+- **It is currently unauthenticated** (see #50 P0). Anyone on the internet, no account needed.
+
+### What an attacker actually gets
+
+**1. Cloud metadata services.** The classic target is the link-local endpoint `169.254.169.254`. On AWS this serves IAM role credentials at `/latest/meta-data/iam/security-credentials/`, which is precisely how the 2019 Capital One breach happened — an SSRF used to lift EC2 role credentials, ~100M records.
+
+Railway runs on GCP, where the metadata service requires a `Metadata-Flavor: Google` header and returns 403 without it. That is real defence-in-depth, and it means a naive `GET http://169.254.169.254/` probably fails today. **Do not rely on it.** It's a property of the current platform, not of our code; it evaporates if we ever add header passthrough, move providers, or run anything locally. I have not verified exactly what Railway's runtime exposes to containers — treat that as unknown rather than safe.
+
+**2. Railway's private network.** Services in a Railway project reach each other over an internal DNS namespace on IPv6. `railway.json` defines two services, so `http://omlete-client.railway.internal:3000/` is reachable from the API container today. The exposure grows with every internal service added later — a Redis, an admin surface, a database.
+
+**3. Loopback.** `http://127.0.0.1:8000/` is our own API. Two consequences: it bypasses any IP-based rate limiting (requests appear to originate locally), and any future admin endpoint bound to localhost-only becomes internet-reachable.
+
+**4. Internal reconnaissance.** Even where the body isn't readable, response timings and error types distinguish "connection refused" from "connected but wrong protocol" — enough to map what's listening.
+
+**5. Request laundering.** Ignoring internal access entirely: an unauthenticated fetch-any-URL endpoint lets someone use our server as an anonymising relay. The target sees Railway's IP, not theirs.
+
+### Why the obvious mitigations fail
+
+This is the part worth internalising. Each of these looks like a fix and isn't.
+
+**"Block hostnames containing localhost or 127.0.0.1."** Defeated by encoding: `http://0177.0.0.1/` (octal), `http://2130706433/` (decimal), `http://127.1/` (shorthand), `http://[::ffff:127.0.0.1]/` (IPv4-mapped IPv6). Also defeated by public DNS names that resolve inward — `localtest.me` and friends resolve to `127.0.0.1`. String matching on the hostname is the wrong layer. **Resolve first, then check the resulting IP.**
+
+**"Check the IP before fetching."** Necessary but not sufficient on its own, because of redirects. We validate `https://evil.example/x`, it's a genuine public address, we fetch it — and it returns `302 Location: http://169.254.169.254/`. `httpx` follows redirects when asked to, and the second request never passes through our check. **This is the mitigation people most often miss.** Either disable automatic redirects and walk the chain manually, re-validating each hop, or don't allow redirects at all.
+
+**"Check the IP, then fetch."** There's still a time-of-check/time-of-use gap. We resolve the name and validate; `httpx` then resolves it *again* when it opens the connection. An attacker serving a TTL-0 record can return a public address to the first lookup and a private one to the second — DNS rebinding.
+
+Closing this properly means connecting to the already-validated IP rather than re-resolving, which is fiddly with TLS (SNI and `Host` have to be set explicitly, and it breaks against some CDNs). **My recommendation: accept this as a known residual risk for now.** It requires an attacker to control a DNS server *and* win a timing race, which is a long way beyond the realistic threat model for this app. Document it, don't over-engineer it. Revisit if the app ever holds credentials worth stealing.
+
+**"Only allow http and https."** Do it — it's free, and it kills `file:///etc/passwd`, `gopher://` and `dict://`. But note `httpx` is HTTP-only anyway, so this is belt-and-braces rather than the main control.
+
+**"Only check IPv4 private ranges."** Railway's private networking is IPv6. Missing `::1`, unique-local `fc00::/7`, link-local `fe80::/10` and IPv4-mapped forms leaves the most relevant path open.
+
+### Reference implementation
+
+```python
+import ipaddress, socket
+from urllib.parse import urlparse
+import httpx
+
+MAX_BYTES = 2 * 1024 * 1024
+MAX_REDIRECTS = 5
+TIMEOUT = httpx.Timeout(10.0, connect=5.0)
+UA = "OmleteBot/1.0 (+https://omlete.app; recipe import)"
+
+
+class BlockedURL(Exception):
+    """The URL resolves somewhere we refuse to fetch."""
+
+
+def _assert_public(host: str) -> None:
+    """Resolve `host` and reject if ANY returned address is non-public."""
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror as exc:
+        raise BlockedURL(f"cannot resolve {host}") from exc
+
+    for info in infos:
+        ip = ipaddress.ip_address(info[4][0])
+        # IPv4-mapped IPv6 (::ffff:127.0.0.1) must be unwrapped before checking
+        if getattr(ip, "ipv4_mapped", None):
+            ip = ip.ipv4_mapped
+        if (
+            ip.is_private or ip.is_loopback or ip.is_link_local
+            or ip.is_reserved or ip.is_multicast or ip.is_unspecified
+        ):
+            raise BlockedURL(f"{host} resolves to non-public address {ip}")
+
+
+def _validate(url: str) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise BlockedURL(f"unsupported scheme: {parsed.scheme!r}")
+    if not parsed.hostname:
+        raise BlockedURL("missing hostname")
+    _assert_public(parsed.hostname)
+
+
+async def fetch_page(url: str) -> str:
+    """Fetch a page, re-validating on every redirect hop."""
+    async with httpx.AsyncClient(
+        follow_redirects=False,          # we walk the chain ourselves
+        timeout=TIMEOUT,
+        headers={"User-Agent": UA},
+    ) as client:
+        for _ in range(MAX_REDIRECTS):
+            _validate(url)               # <-- runs again for each hop
+            async with client.stream("GET", url) as response:
+                if response.is_redirect:
+                    location = response.headers.get("location")
+                    if not location:
+                        raise BlockedURL("redirect without Location")
+                    url = str(response.url.join(location))
+                    continue
+
+                response.raise_for_status()
+
+                # Enforce the size cap while streaming, not after
+                chunks, total = [], 0
+                async for chunk in response.aiter_bytes():
+                    total += len(chunk)
+                    if total > MAX_BYTES:
+                        raise BlockedURL("response too large")
+                    chunks.append(chunk)
+                return b"".join(chunks).decode(
+                    response.encoding or "utf-8", errors="replace"
+                )
+
+        raise BlockedURL("too many redirects")
+```
+
+Three details that carry most of the weight:
+
+1. `_validate()` is inside the redirect loop, so every hop is checked — not just the URL the user typed.
+2. `_assert_public()` iterates **all** `getaddrinfo` results. A hostname with both an A and an AAAA record has to pass on both.
+3. The size cap is enforced **while streaming**. Checking `Content-Length` afterwards is useless against a server that lies or omits it.
+
+### Test cases
+
+These belong in `server/tests/test_recipe_import.py` and need no network:
+
+| Input | Expected |
+|---|---|
+| `http://127.0.0.1:8000/` | `BlockedURL` |
+| `http://169.254.169.254/latest/meta-data/` | `BlockedURL` |
+| `http://[::1]/` | `BlockedURL` |
+| `http://0177.0.0.1/` and `http://2130706433/` | `BlockedURL` |
+| `http://[::ffff:127.0.0.1]/` | `BlockedURL` (exercises the `ipv4_mapped` unwrap) |
+| `http://omlete-client.railway.internal/` | `BlockedURL` |
+| `file:///etc/passwd` | `BlockedURL` (scheme) |
+| Public host → `302` → `http://169.254.169.254/` | `BlockedURL` **on the second hop** |
+| 6-hop redirect chain | `BlockedURL` (too many redirects) |
+| Response streaming past 2 MB | `BlockedURL` (too large) |
+| Ordinary public recipe URL | succeeds |
+
+Mock `socket.getaddrinfo` to make the resolution cases deterministic.
+
+### Residual risks, accepted knowingly
+
+- **DNS rebinding**, as discussed above — needs attacker-controlled DNS plus a race win.
+- **Traffic amplification** — mitigated by the #50 P0 rate limiting, not by this guard. Treat that rate limiting as a hard dependency of shipping this endpoint, not a follow-up.

--- a/docs/PRD_URL_IMPORT.md
+++ b/docs/PRD_URL_IMPORT.md
@@ -236,20 +236,28 @@ Index `source_url` and return 409 with the existing recipe id on re-import. Requ
 - SSRF guard tests: `127.0.0.1`, `169.254.169.254`, `10.x`, `file://`, a redirect from a public host to a private one
 - This is the highest-value test surface in the feature — it's pure functions over fixed input
 
-### Step 3 — Ingredient structurer
+### Step 3 — Ingredient structurer ✅ done
 - `server/ingredient_structurer.py` on Haiku, reusing the `tool_runner` + `find_similar_ingredients` pattern
 - Unit tests with a mocked Anthropic client, mirroring `tests/test_ingredient_service.py`
 - **Risk:** confirm Haiku 4.5 handles structured output + tool use reliably. If not, fall back to Sonnet — still far cheaper than Opus
+- **Still open:** the risk above is unverified. The tests mock the client, so nothing here has exercised a real Haiku call — that needs a live import against a real page before this ships. `MODEL` is a single constant to change if it disappoints.
+- Group headings are only used when they account for every ingredient line. Partial `ingredient_groups()` is common enough that trusting it would silently drop ingredients.
 
-### Step 4 — Model changes
+### Step 4 — Model changes ✅ done
 - Extend `Recipe` and `IngredientRecipe` in `server/lib/types.py`
 - No migration needed (all optional), but confirm existing docs still deserialise
 - Add the `source_url` index
+- **Changed from the plan:** the metadata went on a separate `RecipeMetadata` mixin rather than onto `Recipe`. `Recipe` is the base of `RecipeModelResponse`, which is what generates the JSON schema handed to Claude — extending it would have put `image_url` and `source_url` in front of a model that has no way to know them and every incentive to fill them in. `RecipeDocument` inherits both; the model only ever sees `Recipe`.
+- `IngredientRecipe` also gained `group`, so the headings from step 3 have somewhere to live.
+- Open question 2 resolved: `amount` is now `Optional[float]`. `ItemSource.amount` followed it, and the two `sum()` sites in the list-merge arithmetic went through `_total_amount()`, which ignores unquantified sources instead of treating them as zero.
 
-### Step 5 — Endpoint
+### Step 5 — Endpoint ✅ done
 - `POST /api/recipes/import-from-url/` in `server/main.py`
 - Wire the fallback chain and the error taxonomy above
 - Dedup check on `source_url`
+- The dedup read happens before the fetch, so a re-import costs neither a request nor a token. The index is non-unique (every hand-made recipe has `source_url` unset), so two simultaneous imports of the same URL race to a duplicate rather than an error.
+- The Opus fallback is told to return an empty recipe for a page that has none, which is what turns into the 404. Without that it will always oblige with something.
+- **Not done, still required before this is public:** rate limiting (open question 4). The endpoint makes the server fetch arbitrary URLs and then spends tokens on the result, with no authentication in front of it.
 
 ### Step 6 — Frontend
 - New `LinkTab` in `client/src/routes/create.tsx`, made the default

--- a/docs/PRD_URL_IMPORT.md
+++ b/docs/PRD_URL_IMPORT.md
@@ -36,7 +36,9 @@ All of the below was tested directly against `recipe-scrapers` 15.11.0.
 
 ### Installation
 
-Installs cleanly in a venv with current setuptools; **583 scrapers** available. The `jstyleson` wheel failure seen earlier is a Debian-patched-setuptools artifact (`AttributeError: install_layout`) specific to the sandbox's system Python — **not** a real packaging problem. Still worth confirming on Nixpacks before merge.
+Installs cleanly in a venv with current setuptools; **583 scrapers** available. The `jstyleson` wheel failure seen earlier is a Debian-patched-setuptools artifact (`AttributeError: install_layout`) specific to the sandbox's system Python — **not** a real packaging problem.
+
+**Resolved during implementation:** `recipe-scrapers==15.11.0` installs alongside the full existing `requirements.txt` with `pip check` reporting no broken requirements. It adds ~15 transitive packages (`lxml`, `rdflib`, `pyrdfa3`, `extruct`, `html5lib`, `beautifulsoup4`, `isodate` and friends), which is a meaningful bump to image size and build time but no version conflict. Still worth watching the first Nixpacks build for `lxml` wheel availability.
 
 ### UK site coverage (confirmed present in `SCRAPERS`)
 
@@ -70,10 +72,12 @@ Tested against a realistic schema.org JSON-LD payload:
 
 | Condition | Exception | Our response |
 |---|---|---|
-| Unsupported host, `wild_mode=False` | `WebsiteNotImplementedError` | n/a — we always use `wild_mode=True` |
+| Unsupported host, `supported_only=True` | `WebsiteNotImplementedError` | n/a — we always pass `supported_only=False` |
 | No structured data anywhere | `NoSchemaFoundInWildMode` | → Claude fallback on page text |
 
-`wild_mode=True` is a strict superset: it uses the dedicated scraper when the host is supported and falls back to generic schema.org parsing when it isn't. **Always pass `wild_mode=True`.**
+⚠️ **`wild_mode` is deprecated in 15.11.0** — it emits a `DeprecationWarning` and may be removed. Use **`supported_only=False`**, which is the documented replacement.
+
+Verified equivalent: with `supported_only=False`, a supported host still resolves to its dedicated scraper (confirmed `BBCGoodFood` is returned for a bbcgoodfood.com URL), and unsupported hosts fall back to generic schema.org parsing. Exceptions raised are unchanged. It is a strict superset — **always pass `supported_only=False`**.
 
 ---
 
@@ -123,7 +127,7 @@ Expected latency ~5-8s total, versus 20-60s for the current generate flow. No st
 
 ```python
 async def fetch_page(url: str) -> str        # SSRF-guarded async fetch
-def scrape(html: str, url: str) -> ScrapedRecipe | None   # wild_mode=True
+def scrape(html: str, url: str) -> ScrapedRecipe | None   # supported_only=False
 ```
 
 **SSRF guard — required, not optional.** This endpoint takes a user-supplied URL and makes the server fetch it, then returns the parsed result to the caller. That is a textbook full-read SSRF primitive. See [Appendix A](#appendix-a--ssrf-in-detail) for the full threat model, why the obvious mitigations fail, and a reference implementation.
@@ -219,14 +223,14 @@ Index `source_url` and return 409 with the existing recipe id on re-import. Requ
 
 ## Implementation plan
 
-### Step 1 — Dependency + scraper module
+### Step 1 — Dependency + scraper module ✅ done
 - Add `recipe-scrapers` to `server/requirements.txt`
 - **Verify it builds on Nixpacks** before going further (the sandbox failure was environmental, but confirm)
 - Create `server/recipe_import.py`: `fetch_page()` with the full SSRF guard, `scrape()` wrapping `scrape_html(..., wild_mode=True)`
 - Normalise `yields()` → `Optional[int]` with a range sanity-check
 - Return a `ScrapedRecipe` dataclass
 
-### Step 2 — Tests for step 1 (before wiring anything up)
+### Step 2 — Tests for step 1 (before wiring anything up) ✅ done
 - `server/tests/test_recipe_import.py` with **saved HTML fixtures** — no network in tests
 - Fixtures: a JSON-LD page, a page with `ingredient_groups`, a no-structured-data page, a `"serves 4-6"` yields case
 - SSRF guard tests: `127.0.0.1`, `169.254.169.254`, `10.x`, `file://`, a redirect from a public host to a private one

--- a/docs/PRD_URL_IMPORT.md
+++ b/docs/PRD_URL_IMPORT.md
@@ -1,0 +1,286 @@
+# PRD: Import recipe from a web link
+
+_Child of #50. Verified against `recipe-scrapers` 15.11.0._
+
+---
+
+## Problem
+
+Omlete has two ways to get a recipe in: type your ingredients, or photograph a cookbook. Both are high-effort and low-frequency. **Pasting a link is how people actually acquire recipes**, and every competitor — Paprika, AnyList, Mela, Mealie, Tandoor, and the entire AI-native cohort — supports it.
+
+The UK case is especially strong. BBC Good Food is the [#1 cooking site in the UK](https://www.similarweb.com/top-websites/united-kingdom/food-and-drink/cooking-and-recipes/) at ~30.7M monthly visits, ahead of RecipeTin Eats, Allrecipes, HelloFresh and Jamie Oliver. UK recipes live on the open web, not in an app.
+
+## Solution
+
+A third tab on `/create` — **From link** — that takes a URL and produces a saved recipe.
+
+The important architectural point: **this is a two-stage pipeline, not one.**
+
+```
+URL ──▶ Stage 1: SCRAPE (free, ~1s, zero tokens)
+        └─ title, instructions[], image, prep/cook/total time,
+           yields, description, cuisine, category, source_url
+        └─ ingredients as FREE-TEXT STRINGS  ──▶ Stage 2: STRUCTURE (Haiku)
+                                                  └─ name / amount / unit / category
+                                                  └─ find_similar_ingredients
+                                                  └─ ──▶ _save_recipe()
+```
+
+Stage 1 gets us most of a recipe for nothing. Stage 2 is the only part that needs a model — and it's a *parsing* task, not a generation task, so it can run on Haiku and can't hallucinate the recipe itself. The instructions come through verbatim from the source.
+
+That makes this **both cheaper and more accurate than the existing image-extraction path**, which pays Opus prices to invent structure from pixels.
+
+## Verified findings
+
+All of the below was tested directly against `recipe-scrapers` 15.11.0.
+
+### Installation
+
+Installs cleanly in a venv with current setuptools; **583 scrapers** available. The `jstyleson` wheel failure seen earlier is a Debian-patched-setuptools artifact (`AttributeError: install_layout`) specific to the sandbox's system Python — **not** a real packaging problem. Still worth confirming on Nixpacks before merge.
+
+### UK site coverage (confirmed present in `SCRAPERS`)
+
+`bbcgoodfood.com` · `jamieoliver.com` · `greatbritishchefs.com` · `waitrose.com` · `realfood.tesco.com` · `mob.co.uk` · `mobkitchen.co.uk` · `gousto.co.uk` · `thehappyfoodie.co.uk` · `schoolofwok.co.uk` · `books.ottolenghi.co.uk` · `tofoo.co.uk`
+
+Not covered by a dedicated scraper: `bbc.co.uk/food`, `olivemagazine.com`, `deliciousmagazine.co.uk`, `nigella.com`, `riverford.co.uk` — these should still work through `wild_mode` if they publish JSON-LD.
+
+### What the scraper returns
+
+Tested against a realistic schema.org JSON-LD payload:
+
+| Field | Type returned | Notes |
+|---|---|---|
+| `title()` | `str` | |
+| `total_time()` / `prep_time()` / `cook_time()` | **`int`, minutes** | ISO 8601 durations already parsed for us |
+| `yields()` | `str` — `'6 servings'` | ⚠️ see gotcha below |
+| `image()` | `str` URL | |
+| `ingredients()` | **`list[str]` — free text** | ⚠️ the core constraint |
+| `ingredient_groups()` | `[IngredientGroup(ingredients=[...], purpose=None)]` | `purpose` carries "For the sauce:" headings |
+| `instructions_list()` | `list[str]` | |
+| `nutrients()` | `dict[str, str]` — `{'calories': '636 calories'}` | strings, need parsing |
+| `ratings()` | `float` — `4.7` | the *site's* crowd rating, not the user's |
+| `author()` / `category()` / `cuisine()` / `description()` | `str` | |
+| `to_json()` | `dict` of everything above | |
+
+**⚠️ Gotcha:** given `recipeYield: "serves 4-6"`, `yields()` returned `'6 servings'` — it takes the **upper bound** of a range. Best-effort normalisation; sanity-check the parsed integer rather than trusting it.
+
+**⚠️ The core constraint:** ingredients arrive as `'2 onions, finely chopped'`, not `{name, amount, unit}`. `recipe-scrapers` ships **no** ingredient parser (only internal `_grouping_utils` / `_utils`). Stage 2 is mandatory.
+
+### Failure modes (clean and distinguishable)
+
+| Condition | Exception | Our response |
+|---|---|---|
+| Unsupported host, `wild_mode=False` | `WebsiteNotImplementedError` | n/a — we always use `wild_mode=True` |
+| No structured data anywhere | `NoSchemaFoundInWildMode` | → Claude fallback on page text |
+
+`wild_mode=True` is a strict superset: it uses the dedicated scraper when the host is supported and falls back to generic schema.org parsing when it isn't. **Always pass `wild_mode=True`.**
+
+---
+
+## UX
+
+### The Create page
+
+Tabs become: **From link** · Generate · Extract from Images — with *From link* as the default (it will be the most-used path; today `extract` is the default at `create.tsx:16`).
+
+```
+┌──────────────────────────────────────────────┐
+│  [ From link ]  Generate   Extract from Images│
+├──────────────────────────────────────────────┤
+│  Paste a recipe link                          │
+│  ┌────────────────────────────────┐ ┌──────┐ │
+│  │ https://bbcgoodfood.com/...    │ │Import│ │
+│  └────────────────────────────────┘ └──────┘ │
+│                                               │
+│  Works with BBC Good Food, Jamie Oliver,      │
+│  Tesco Real Food, Waitrose, Mob and 580 more. │
+└──────────────────────────────────────────────┘
+```
+
+States: idle → `Reading the page…` (stage 1) → `Sorting the ingredients…` (stage 2) → recipe card + "View recipe" / "Add to list". Errors surface inline with the reason and a "try extracting from a photo instead" escape hatch.
+
+Expected latency ~5-8s total, versus 20-60s for the current generate flow. No streaming needed.
+
+### PWA share target
+
+`manifest.webmanifest` already exists. Adding a `share_target` lets Android users share a URL straight from Chrome, Instagram or TikTok into Omlete — which is exactly the mechanic the AI-native cohort competes on.
+
+```json
+"share_target": {
+  "action": "/create",
+  "method": "GET",
+  "params": { "title": "title", "text": "text", "url": "url" }
+}
+```
+
+`/create` reads `?url=` on mount and pre-fills the field. Cheap, and it's the difference between a feature people try once and one they use constantly.
+
+---
+
+## Technical design
+
+### New module: `server/recipe_import.py`
+
+```python
+async def fetch_page(url: str) -> str        # SSRF-guarded async fetch
+def scrape(html: str, url: str) -> ScrapedRecipe | None   # wild_mode=True
+```
+
+**SSRF guard — required, not optional.** This endpoint takes a user-supplied URL and makes the server fetch it. Without a guard it's a hole straight into the internal network. Must:
+
+- Allow only `http`/`https` schemes
+- Resolve the hostname and **reject private/reserved ranges**: `127.0.0.0/8`, `10/8`, `172.16/12`, `192.168/16`, `169.254/16` (cloud metadata — `169.254.169.254` is the one that matters), `::1`, unique-local v6
+- Re-check after **every redirect**, cap redirects at ~5
+- Cap response size (~2 MB) and timeout (~10s)
+- Send a real User-Agent; many sites 403 a default `python-httpx`
+
+`httpx==0.28.1` is already in `requirements.txt`, so use `httpx.AsyncClient` rather than `scrape_me()` — the latter fetches synchronously and would block the event loop.
+
+### New module: `server/ingredient_structurer.py`
+
+Takes `list[str]` of raw ingredient lines plus the category list; returns `list[IngredientModelResponse]`.
+
+Reuses the existing `tool_runner` + `find_similar_ingredients` + `output_config` pattern from `main.py:124-133`, but on **`claude-haiku-4-5-20251001`**.
+
+Prompt requirements:
+- Split each line into `name`, `amount`, `unit`
+- **Strip preparation from the name**: `"2 onions, finely chopped"` → name `onions`, note `finely chopped`
+- Call `find_similar_ingredients` to canonicalise against our vocabulary
+- Assign a category from the user's list for new ingredients
+- Preserve group headings from `ingredient_groups()` where present
+
+### Endpoint: `POST /api/recipes/import-from-url/`
+
+```
+Request:  { "url": "https://www.bbcgoodfood.com/recipes/classic-lasagne" }
+200 →     RecipeDocument (same shape as the existing extract endpoint)
+400 →     malformed URL, unsupported scheme, or blocked host
+404 →     page fetched but no recipe found (after Claude fallback)
+502 →     source site unreachable / timed out
+409 →     already imported (returns the existing recipe id)
+```
+
+Flow:
+
+1. Validate + SSRF-guard the URL
+2. Fetch HTML
+3. `scrape_html(html, org_url=url, wild_mode=True)`
+4. On `NoSchemaFoundInWildMode` → strip the page to text and run the **existing** Opus generate path as a fallback
+5. Structure the ingredient strings (Haiku)
+6. Map to `RecipeDocument` and `_save_recipe()`
+
+### Model changes
+
+`server/lib/types.py` — extend `Recipe`:
+
+```python
+class Recipe(BaseModel):
+    title: str
+    instructions: list[str]
+    servings: Optional[int] = None
+    prep_minutes: Optional[int] = None
+    cook_minutes: Optional[int] = None
+    total_minutes: Optional[int] = None
+    image_url: Optional[str] = None
+    source_url: Optional[str] = None
+    source_name: Optional[str] = None      # e.g. "BBC Good Food"
+    description: Optional[str] = None
+    cuisine: Optional[str] = None
+```
+
+All optional, so existing documents deserialise unchanged — **no migration needed**.
+
+`IngredientRecipe` gains `note: Optional[str]` for the stripped prep text.
+
+### Deduplication
+
+Index `source_url` and return 409 with the existing recipe id on re-import. Requires the index work from #50's P0 anyway.
+
+---
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Scrape library | `recipe-scrapers`, `wild_mode=True` always | 583 dedicated scrapers + generic schema.org fallback in one call |
+| Fetching | `httpx.AsyncClient`, not `scrape_me()` | `scrape_me()` blocks the event loop |
+| Stage 2 model | Haiku 4.5 | Parsing, not generation. ~95% cheaper than Opus |
+| No-structured-data fallback | Existing Opus generate path on page text | Reuses code; rare enough that cost doesn't matter |
+| Import the site's rating? | **No** | It's the crowd's rating, not the user's. Our `rating` field means "did *I* like it" |
+| Import nutrition? | **No, not yet** | Returns unparsed strings; out of scope per #50 |
+| Hero image | Store the URL, don't re-host | Cheap. Hotlinks can rot — re-hosting is a later improvement |
+| Save directly or preview first? | **Preview, then save** | See open question 1 — recommended but costs an extra step |
+| Default Create tab | From link | Will be the most-used path |
+| robots.txt | Ignore, but always store `source_url` | User is importing a page they're already viewing; attribution is the right etiquette |
+
+---
+
+## Implementation plan
+
+### Step 1 — Dependency + scraper module
+- Add `recipe-scrapers` to `server/requirements.txt`
+- **Verify it builds on Nixpacks** before going further (the sandbox failure was environmental, but confirm)
+- Create `server/recipe_import.py`: `fetch_page()` with the full SSRF guard, `scrape()` wrapping `scrape_html(..., wild_mode=True)`
+- Normalise `yields()` → `Optional[int]` with a range sanity-check
+- Return a `ScrapedRecipe` dataclass
+
+### Step 2 — Tests for step 1 (before wiring anything up)
+- `server/tests/test_recipe_import.py` with **saved HTML fixtures** — no network in tests
+- Fixtures: a JSON-LD page, a page with `ingredient_groups`, a no-structured-data page, a `"serves 4-6"` yields case
+- SSRF guard tests: `127.0.0.1`, `169.254.169.254`, `10.x`, `file://`, a redirect from a public host to a private one
+- This is the highest-value test surface in the feature — it's pure functions over fixed input
+
+### Step 3 — Ingredient structurer
+- `server/ingredient_structurer.py` on Haiku, reusing the `tool_runner` + `find_similar_ingredients` pattern
+- Unit tests with a mocked Anthropic client, mirroring `tests/test_ingredient_service.py`
+- **Risk:** confirm Haiku 4.5 handles structured output + tool use reliably. If not, fall back to Sonnet — still far cheaper than Opus
+
+### Step 4 — Model changes
+- Extend `Recipe` and `IngredientRecipe` in `server/lib/types.py`
+- No migration needed (all optional), but confirm existing docs still deserialise
+- Add the `source_url` index
+
+### Step 5 — Endpoint
+- `POST /api/recipes/import-from-url/` in `server/main.py`
+- Wire the fallback chain and the error taxonomy above
+- Dedup check on `source_url`
+
+### Step 6 — Frontend
+- New `LinkTab` in `client/src/routes/create.tsx`, made the default
+- Two-phase progress copy ("Reading the page…" → "Sorting the ingredients…")
+- **Real error handling** — this is the first feature that genuinely needs it, and it's a #50 P0 item
+- Surface `image_url`, times and servings on `RecipeCard` and the recipe detail page
+
+### Step 7 — Share target
+- `share_target` in `manifest.webmanifest`
+- `/create` reads `?url=` on mount and pre-fills
+- Test on Android Chrome — iOS does not support Web Share Target
+
+### Step 8 — Docs
+- Update `README.md` / `CLAUDE.md` (both currently describe endpoints that don't exist)
+
+**Suggested sequencing:** steps 1-2 are self-contained and testable with zero network and zero tokens — worth doing first and merging on their own. Steps 3-5 are the backend spine. Steps 6-7 are frontend. Step 4 (model changes) unblocks other #50 work, so pulling it earlier is reasonable.
+
+---
+
+## Verification
+
+1. A BBC Good Food URL produces a complete recipe — title, steps, image, times, servings — with structured ingredients and **zero Opus calls**
+2. Ingredients are canonicalised: importing a recipe with "spring onions" matches an existing "scallions" entry rather than creating a duplicate
+3. `"2 onions, finely chopped"` yields name `onions`, amount `2`, with `finely chopped` in the note
+4. A recipe with "For the sauce:" headings preserves the grouping
+5. An unsupported site that publishes JSON-LD still imports via `wild_mode`
+6. A blog with no structured data falls back to Claude and still produces a recipe
+7. Re-importing the same URL returns 409 with the existing recipe rather than a duplicate
+8. `http://169.254.169.254/latest/meta-data/` is rejected, as is a public URL that 302s to a private address
+9. A 50 MB response is truncated, not swallowed
+10. Sharing a link from Chrome on Android opens Omlete with the URL pre-filled
+
+---
+
+## Open questions
+
+1. **Preview before save, or save immediately?** The existing extract flow saves immediately. Preview is better UX — Paprika does it, and it stops bad imports polluting the library — but it's an extra screen and an extra state. *Recommendation: preview.* Import quality varies too much across sites to save blind.
+2. **What do we do about `amount` on unquantified ingredients?** `IngredientRecipe.amount` is currently a **required `float`**, so "salt and pepper to taste" has no honest representation and the model presumably invents one. This is a pre-existing wart that URL import will hit constantly. *Recommendation: make `amount` `Optional[float]`* — but it touches the list-merge arithmetic at `main.py:540-557`, so it needs its own care.
+3. **Video links?** Pasting an Instagram or TikTok URL will fail with `NoSchemaFoundInWildMode`. Do we detect those hosts and show "video import isn't supported yet", or let it fall through to the generic error? A clear message is cheap and this *will* happen.
+4. **Rate limiting.** This endpoint makes the server fetch arbitrary URLs. Even with the SSRF guard it's an abuse vector for traffic amplification. Needs the #50 P0 rate-limiting work — arguably a hard dependency rather than a nice-to-have.

--- a/docs/WHISK_ANALYSIS.md
+++ b/docs/WHISK_ANALYSIS.md
@@ -1,0 +1,230 @@
+# Whisk / Samsung Food — Deep Dive & Differentiation Strategy
+
+_July 2026. Companion to `GAP_ANALYSIS.md`._
+
+---
+
+## 1. Why this competitor matters more than the others
+
+Whisk is not just another recipe app. It is **the company that already tried to build what Omlete is building**, took it further than anyone, and then got absorbed into a hardware business.
+
+- Founded **2012 by Nick Holzherr** in **Birmingham, UK**, launched January 2013 after he pitched it to Lord Sugar as a 2012 *Apprentice* finalist.
+- Raised **$39.1M across 5 rounds**.
+- Built the **Food Genome** — the core technology, described below.
+- Pre-acquisition it powered **500M+ recipe interactions per month** across publishers, brands and retailers.
+- **Acquired by Samsung NEXT in March 2019.** Holzherr went on to lead ~120 people building the Samsung Food experience.
+- Rebranded **Samsung Food** in 2023; global launch across **104 countries, 8 languages**.
+
+So the strategic read is: *the thesis was right, it was validated with real money and real scale, and the company that proved it is now optimising for selling refrigerators.* That's both the threat and the opening.
+
+---
+
+## 2. The Food Genome — what it actually is
+
+This is the piece worth understanding properly, because it's the closest thing in the market to what `ingredient_service.py` is reaching for.
+
+Whisk's Food Genome is an **AI/NLP-built food ontology** that maps:
+
+| Axis | What it encodes |
+|---|---|
+| **Identity** | Canonical ingredients and their relationships (synonyms, hypernyms, varieties) |
+| **Products** | Mapping from a recipe ingredient string → an actual purchasable SKU at a specific retailer |
+| **Nutrition** | Per-ingredient nutritional data, aggregated to recipe and per-serving |
+| **Perishability** | How long things last — feeds expiry and waste features |
+| **Flavour** | Ingredient affinity, used for substitutions and recommendations |
+| **Availability** | What's actually in stock, seasonally and per-store |
+
+It's described as "an always evolving food ontology that enables machine learning algorithms to map the relationships between ingredients, products, and recipes."
+
+### The critical observation for Omlete
+
+**Whisk spent roughly seven years and $39M building the identity axis. In 2026 you get most of it for the price of an embedding call.**
+
+`ingredient_service.py` — sixty lines of Voyage-4 embeddings plus a Mongo `$vectorSearch` — does the ingredient-identity job that was Whisk's original moat. That moat has been commoditised by foundation models, and Omlete is already standing on the other side of it.
+
+**But identity is one axis of six.** The other five — products, nutrition, perishability, flavour, availability — are *data* problems, not model problems. No amount of Claude gets you Tesco's SKU catalogue or live stock levels. Those required partnerships, and that's where the real defensibility sat.
+
+The honest conclusion: **don't try to rebuild the Food Genome.** Pick the axes where a model substitutes for data (identity, flavour, substitution) and skip the ones that need contracts (products, availability), or rent them.
+
+---
+
+## 3. Full feature inventory: Samsung Food today
+
+### Recipe acquisition
+- URL import from any site (the original Whisk capability, built on their recipe parser)
+- 160,000–240,000 recipes in the built-in library
+- Browser extension for one-click saving — **though multiple reviews report it has been broken since the 2023 rebrand**
+- Recipe format standardisation and auto-organisation
+
+### AI features
+- **Food AI recipe transformation** — take a saved recipe and have the model convert it to vegan/vegetarian, make it more nutritionally balanced, or rewrite it around ingredients you already have
+- **Vision AI** — photograph a meal, get calorie and nutrition estimates. **Galaxy devices only.**
+- AI-personalised weekly meal plans (Food+ tier)
+
+### Planning and shopping
+- Meal planner calendar
+- Auto-generated shopping lists from recipes and plans
+- **Shoppable lists → checkout at real retailers.** 29 integrated online grocers globally. UK partners include **Tesco, Asda, Sainsbury's, Waitrose and Ocado** (Sainsbury's added Jan 2021); US includes Kroger.
+- Ingredient → product (SKU) matching, with prices
+
+### Health
+- Auto-derived nutrition per recipe and per serving
+- **Samsung Health integration** — meal recommendations driven by BMI, body composition and calorie consumption
+- Per-recipe "Health Score"
+
+### Social and collaboration
+- **Communities**, public and private, organised around themes ("vegan diet", "beginner friendly")
+- Follow other users and food creators; creator profiles with Instagram/YouTube/TikTok links
+- **Share recipes, shopping lists AND the meal planner** with anyone holding an account — invite by name, email, text or social
+
+### Ecosystem
+- Family Hub smart fridge integration; send recipes to connected ovens
+- iOS, Android, Web, Galaxy
+- **B2B platform** — recipe CMS for brands and grocers. This was Whisk's actual revenue engine.
+
+### Pricing
+- Free tier, plus **Samsung Food+** at **$6.99/month or $59.99/year** (~£5.50/month UK), 7-day trial. Purchasable with Samsung Rewards points.
+
+---
+
+## 4. The gap list — what they have that Omlete doesn't
+
+Beyond the table-stakes items already in `GAP_ANALYSIS.md` (URL import, photos, search, servings, times, meal plan, pantry, cook mode, offline, auth), Whisk-specific gaps:
+
+| # | Gap | Severity | Notes |
+|---|---|:--:|---|
+| 1 | **Shoppable lists → real checkout** | 🔴 | 29 retailers. The single biggest functional gap. Business development, not engineering. |
+| 2 | **Ingredient → SKU/product matching** | 🔴 | "500g plain flour" → a real Tesco product with a price. Omlete stops at the string. |
+| 3 | **Nutrition data** | 🟠 | Auto-derived per recipe/serving. Needs a food composition database, not a model. |
+| 4 | **Recipe transformation** | 🟠 | Omlete *generates* recipes but can't *transform* an existing one. This one is cheap for you — it's a Claude call over a recipe you already hold. |
+| 5 | **Household collaboration** | 🟠 | Shared recipes + lists + meal planner. Blocked on your missing auth layer. |
+| 6 | **Social / communities** | 🟡 | Follow creators, public/private communities. Real retention driver; expensive to build; needs scale to work at all. |
+| 7 | **Meal photo → nutrition (Vision AI)** | 🟡 | Galaxy-only for them. Claude vision does this today, on any device. |
+| 8 | **Appliance integration** | ⚪ | Not realistically available to you and not worth chasing. |
+| 9 | **B2B recipe CMS** | ⚪ | Different business. Flagged only because it's where their money came from. |
+
+---
+
+## 5. Where Whisk is weak — the actual openings
+
+These are recurring themes in third-party reviews (MealThinker, Plan to Eat, UK reviewers) rather than anything Samsung publishes. Treat them as strong signals, not audited fact.
+
+### 🎯 Opening 1 — Serving-size changes don't propagate to shopping lists
+
+Reviewers report this as a persistent, unfixed bug: change the servings on a recipe and the shopping list doesn't follow.
+
+**This is precisely the problem Omlete's data model already solves.** `ItemSource` (`main.py:519-595`) tracks which recipe contributed which amount to every list item, so amounts recompute correctly on add and remove. Samsung bolted scaling on top of a merge-and-forget list; you built the provenance in from the start.
+
+You don't have servings yet — but when you add them, the plumbing to make scaling flow correctly into the list is *already written*. That's a feature you can ship correct on day one that a 120-person team has left broken for months.
+
+### 🎯 Opening 2 — No leftovers or batch-cooking model
+
+Reported clearly: cook a big batch on Sunday and the app has no way to factor it into the rest of the week.
+
+Nobody in the market handles this. And again, `ItemSource` is the right shape — it already expresses "this quantity came from that source." Extending it from *contribution* to *consumption* (a batch produces N portions; meals draw them down) is a natural evolution of code you have, not a new subsystem.
+
+This is arguably the single most differentiated feature available to you.
+
+### 🎯 Opening 3 — Pantry is paywalled and basic
+
+Samsung Food doesn't know what's in your fridge unless you pay, and reviewers describe the pantry as thin even then.
+
+There's a structural reason: **Samsung's shopping list monetises buying, and Samsung's hardware business monetises fridges.** An app that's excellent at helping you use up what you already own works against both. Omlete has no such conflict.
+
+### 🎯 Opening 4 — One grocery store per shopping list
+
+A real constraint for households that split a shop across Aldi and a Tesco top-up — which in the UK is most households.
+
+### 🎯 Opening 5 — The Health Score is actively disliked
+
+Samsung Food assigns every recipe a "Health Score" labelling food good or bad. Multiple users have called this out as "seeped in fat phobia and diet culture language."
+
+**Not scoring people's food is a free positioning win.** It costs nothing to build and directly answers a stated grievance.
+
+### 🎯 Opening 6 — Post-acquisition decay
+
+The pattern across reviews: bugs acknowledged but unfixed for months, a browser extension broken since 2023, support described as unresponsive. This is what happens when a beloved indie product becomes a feature of an appliance division — the KPI stops being "do home cooks love this" and becomes "does this sell Family Hubs."
+
+### 🎯 Opening 7 — Device bias
+
+Vision AI is Galaxy-only. Samsung Health integration presumes a Samsung phone. Collaboration requires every household member to hold a Samsung Food account.
+
+Omlete is a PWA. **Device-neutral, install-free, share-by-link** is a genuine wedge — and it's AnyList's entire business, except AnyList has no AI.
+
+---
+
+## 6. Where Omlete is already better
+
+Worth being clear-eyed about, because these are the foundations to build the strategy on.
+
+1. **Source-tracked list arithmetic.** `ItemSource` is a better data model than theirs. Verified by their own reported scaling bug.
+2. **Generate-from-ingredients as a first-class flow.** Whisk *imports* recipes; it doesn't invent them. Omlete's `/recipes/generate/` starts from what you have.
+3. **Multi-photo cookbook extraction into one recipe.** Handles a two-page spread. Most competitors treat each photo as a separate recipe.
+4. **Plan vs Shop modes.** Same data, two intents. Genuinely thoughtful and rare.
+5. **No moralising about food.**
+
+---
+
+## 7. Strategy: what Omlete should be that Samsung Food isn't
+
+**You cannot beat Samsung Food on breadth.** 120 people, $39M of accumulated food data, retailer contracts in 29 markets. Competing feature-for-feature loses.
+
+The opening is that Samsung Food is a **discovery-and-acquisition** app — *find a recipe → buy the ingredients* — because that's what monetises. Omlete's origin story is the inverse.
+
+### The positioning
+
+> **Samsung Food helps you decide what to buy. Omlete helps you use what you have.**
+
+Different emotional job: not aspiration and inspiration, but **reducing waste and killing the 6pm "what do we eat" decision**. Samsung is structurally bad at this — their pantry is paywalled and thin *because* helping you cook from an empty-ish fridge doesn't sell groceries or refrigerators.
+
+### The three-feature spine
+
+**1. Pantry with semantic matching.**
+You have the best ingredient vocabulary of anyone — embedded, canonicalised, similarity-scored. SuperCook does this with a fixed 2,000-item taxonomy; you can do it with free text and embeddings. "I have scallions" satisfies a recipe calling for spring onions. Close the loop: check an item off a shopping list → it enters the pantry → the next list omits it.
+
+**2. "What can I make?" ranked by coverage.**
+Vector-match pantry contents against the recipe library. Rank by percentage covered. Surface "you're 2 ingredients away from X." This is the app's stated premise, finally delivered — and it's the natural home for the tech you've already built.
+
+**3. Leftovers and batch cooking as first-class objects.**
+A recipe yields portions; portions get consumed across days; the meal plan and the shopping list both account for them. Nobody does this. `ItemSource` is already the right shape.
+
+### Supporting moves, in rough priority order
+
+- **Semantic + unit-aware list merging.** Immediate, visible, uses code you've written. Fixes "spring onions" and "scallions" appearing as two lines. *This should ship first — it's the cheapest demonstration of the whole thesis.*
+- **Recipe transformation** ("make this vegan", "halve it", "swap the crème fraîche for what I have"). One Claude call over a recipe you already hold. Matches a headline Samsung Food+ feature at near-zero cost.
+- **Waste-driven suggestions.** Pantry items by age, plus items that have lingered unchecked on lists, bias `suggest_meals`. A concrete reason to open the app on a Tuesday.
+- **Household sharing via link, no account required.** Needs the auth work from Phase 0, but a share-by-link PWA list beats "everyone install Samsung Food."
+- **UK-first import.** Verified: `recipe-scrapers` already covers bbcgoodfood.com, jamieoliver.com, greatbritishchefs.com, waitrose.com, realfood.tesco.com, mob.co.uk, gousto.co.uk, thehappyfoodie.co.uk and more. UK aisle ordering, UK units, UK sources.
+- **Explicitly no health scores.** State it. It's a differentiator that costs a sentence.
+
+### What to deliberately *not* build
+
+- Ingredient → SKU matching and grocery checkout. Needs retailer contracts. In the US, [Instacart's Developer Platform](https://docs.instacart.com/developer_platform_api/guide/concepts/shopping_list/) will do the product matching and hand back a hosted list URL — worth knowing, but there's no comparably easy UK equivalent. Revisit only if the app gets traction.
+- A nutrition database. Needs a food composition dataset (OpenFoodFacts is the free route Tandoor uses). Model-estimated nutrition is a liability, not a feature.
+- Social/communities. Needs scale to be anything but empty rooms.
+- Appliance integration. Not available to you.
+
+---
+
+## 8. The one-paragraph version
+
+Whisk proved the thesis, built a genuine moat in ingredient understanding, and sold to a hardware company that is now optimising it for fridge attach rate. Foundation models have since commoditised the identity half of that moat — Omlete gets it from an embedding call. The remaining half needs retailer data, which isn't winnable and shouldn't be chased. The opening is that Samsung Food is structurally committed to helping you *buy* food, which makes it structurally bad at helping you *use* food. Omlete should be the app for what's already in the fridge: pantry, coverage-ranked suggestions, leftovers as first-class objects, and shopping lists that are semantically smart because the ingredient graph was there from the beginning.
+
+---
+
+## Sources
+
+- [Samsung Next — Whisk's genome and ontology for AI Food](https://component.samsungnext.com/blog/component-whisk-food-genome-uses-ai)
+- [VentureBeat — How Whisk is using its food genome to turn recipes into smart shopping lists](https://venturebeat.com/ai/how-whisk-is-using-its-food-genome-to-turn-recipes-into-smart-shopping-lists/)
+- [Whisk Adds Sainsbury's to Partner Ecosystem — Businesswire](https://www.businesswire.com/news/home/20210126005433/en/Whisk-Adds-Sainsburys-to-Partner-Ecosystem-to-Enable-Shoppable-Recipes-Across-the-UK)
+- [Whisk adds Kroger to Partner Ecosystem — Perishable News](https://perishablenews.com/retailfoodservice/whisk-adds-the-kroger-co-to-partner-ecosystem-making-online-recipes-instantly-shoppable-at-kroger-family-of-stores/)
+- [Samsung announces global launch of Samsung Food — Samsung Newsroom UK](https://news.samsung.com/uk/samsung-announces-global-launch-of-samsung-food-an-ai-powered-personalised-food-and-recipe-service)
+- [The Story of Samsung Food with Nick Holzherr — The Spoon](https://thespoon.tech/the-story-of-samsung-food-with-nick-holzherr/)
+- [Food tech firm Whisk.com bought by Samsung — BusinessCloud](https://businesscloud.co.uk/news/food-tech-firm-whiskcom-bought-by-samsung/)
+- [Whisk — Crunchbase](https://www.crunchbase.com/organization/whisk)
+- [Samsung Food App 2026: Vision AI Features, Limits & Best Alternatives — MealThinker](https://mealthinker.com/blog/samsung-food-alternative)
+- [Samsung Food Review: Pros and Cons — Plan to Eat](https://www.plantoeat.com/blog/2026/01/samsung-food-review-pros-and-cons/)
+- [Whisk/Samsung Food App Review UK — Home Cooks](https://home-cooks.co.uk/pages/review-whisk)
+- [Samsung Food Communities FAQ](https://support.samsungfood.com/hc/en-us/articles/18365378908820-Communities-FAQs)
+- [Sharing & Collaboration on Samsung Food](https://support.samsungfood.com/hc/en-us/articles/18689681101716-Sharing-Collaboration-on-Samsung-Food)
+- [Food Plus — Samsung Food](https://samsungfood.com/food-plus/)

--- a/server/data_models/__init__.py
+++ b/server/data_models/__init__.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 from beanie import Document
 from pydantic import BaseModel, Field
 
-from lib.types import Ingredient, IngredientRecipe, Recipe
+from lib.types import Ingredient, IngredientRecipe, Recipe, RecipeMetadata
 
 
 class IngredientDocument(Document, Ingredient):
@@ -16,18 +16,25 @@ class IngredientDocument(Document, Ingredient):
         name = "ingredients"
 
 
-class RecipeDocument(Document, Recipe):
+class RecipeDocument(Document, Recipe, RecipeMetadata):
     ingredients: list[IngredientRecipe]
     rating: Optional[int] = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     class Settings:
         name = "recipes"
+        # Import looks a recipe up by source_url on every request to avoid
+        # re-importing the same page. Not unique: every hand-made recipe has
+        # source_url unset, and a unique index would collide on the second one.
+        indexes = ["source_url"]
 
 
 class ItemSource(BaseModel):
     recipe_id: Optional[str] = None
-    amount: float
+    # None for an ingredient the recipe never quantified ("salt, to taste").
+    # It still earns a source so the item survives until every recipe using it
+    # is removed from the list.
+    amount: Optional[float] = None
 
 
 class ListItem(BaseModel):

--- a/server/ingredient_structurer.py
+++ b/server/ingredient_structurer.py
@@ -1,0 +1,109 @@
+"""Turn free-text ingredient lines into structured ingredients.
+
+This is stage 2 of the URL import pipeline described in docs/PRD_URL_IMPORT.md.
+`recipe_import.scrape()` hands back lines exactly as the source page wrote them
+— ``"2 onions, finely chopped"`` — because recipe-scrapers ships no ingredient
+parser. This module splits those into name / amount / unit and canonicalises the
+names against our vocabulary.
+
+It runs on Haiku rather than Opus. This is a parsing task over text we already
+have, not a generation task: the model is never asked to invent an ingredient,
+only to cut a line into fields, so the cheap model is the right one and the
+blast radius of a bad answer is a mis-split line rather than a made-up recipe.
+"""
+
+from typing import Optional
+
+from anthropic import AsyncAnthropic, transform_schema
+from pydantic import BaseModel, Field, TypeAdapter
+
+from lib.types import IngredientModelResponse
+from recipe_import import IngredientGroup
+from tools import find_similar_ingredients
+
+MODEL = "claude-haiku-4-5-20251001"
+_MAX_TOKENS = 4096
+
+
+class StructuredIngredients(BaseModel):
+    """Wrapper so the model returns an object rather than a bare array."""
+
+    ingredients: list[IngredientModelResponse] = Field(
+        description="One entry per input line, in the order the lines were given."
+    )
+
+
+_schema = transform_schema(TypeAdapter(StructuredIngredients).json_schema())
+
+
+def _format_lines(
+    lines: list[str], groups: list[IngredientGroup] | None
+) -> str:
+    """Render the ingredient lines for the prompt, keeping any headings.
+
+    Groups are used when the page published them and they actually cover the
+    lines; otherwise the flat list is authoritative. Sites are inconsistent
+    enough about ingredient_groups() that trusting it blindly would silently
+    drop ingredients.
+    """
+    if groups:
+        grouped = [line for g in groups for line in g.ingredients]
+        if sorted(grouped) == sorted(lines):
+            blocks = []
+            for group in groups:
+                heading = group.purpose or "(no heading)"
+                body = "\n".join(f"- {line}" for line in group.ingredients)
+                blocks.append(f"{heading}\n{body}")
+            return "\n\n".join(blocks)
+
+    return "\n".join(f"- {line}" for line in lines)
+
+
+def _build_prompt(
+    lines: list[str], categories_str: str, groups: list[IngredientGroup] | None
+) -> str:
+    return f"""Split each of these recipe ingredient lines into structured fields. They were copied verbatim from a recipe page.
+
+{_format_lines(lines, groups)}
+
+Rules:
+- Return exactly one entry per line, in the same order. Never merge or drop a line.
+- `name` is the ingredient alone, singular where natural: "2 onions, finely chopped" -> "onions".
+- `note` holds any preparation you stripped off the name: "finely chopped". Leave it unset if there is none.
+- `amount` is the numeric quantity. Convert fractions and ranges to a single number ("1 1/2" -> 1.5, "2-3" -> 2.5). If the line gives no quantity ("salt and pepper to taste", "a splash of olive oil"), leave `amount` unset — do not invent one.
+- `unit` is the measure the amount is in ("g", "tbsp", "ml"). For things counted rather than measured ("2 onions"), use an empty string.
+- `group` is the heading the line sat under, if it was given one above. Use an empty heading of "(no heading)" as unset.
+- You must call find_similar_ingredients with every name you produce. When it returns a match, use the matched name and unit verbatim instead of yours and set is_new=false — this is how we avoid storing "spring onions" and "scallions" as two different things.
+- For each NEW ingredient (is_new=true), assign a category from this list: [{categories_str}]. For existing ingredients matched via the tool, leave the category as 'Other' — the system will use the cached category.
+
+Output in the given JSON format."""
+
+
+async def structure_ingredients(
+    lines: list[str],
+    categories_str: str,
+    client: AsyncAnthropic,
+    groups: Optional[list[IngredientGroup]] = None,
+) -> list[IngredientModelResponse]:
+    """Parse free-text ingredient lines into structured, canonicalised entries.
+
+    Returns an empty list for empty input without calling the model.
+    """
+    if not lines:
+        return []
+
+    runner = client.beta.messages.tool_runner(
+        model=MODEL,
+        max_tokens=_MAX_TOKENS,
+        messages=[{
+            "role": "user",
+            "content": _build_prompt(lines, categories_str, groups),
+        }],
+        tools=[find_similar_ingredients],
+        stream=True,
+        output_config={"format": {"type": "json_schema", "schema": _schema}},
+    )
+
+    final_message = await runner.until_done()
+    parsed = StructuredIngredients.model_validate_json(final_message.content[0].text)
+    return parsed.ingredients

--- a/server/lib/types.py
+++ b/server/lib/types.py
@@ -19,7 +19,18 @@ class IngredientRecipe(BaseModel):
     unit: str = Field(
         examples=["grams", "teaspoon", "tablespoon", "teaspoons", "tablespoons", "ml"]
     )
-    amount: float
+    amount: Optional[float] = Field(
+        default=None,
+        description="Leave unset when the source gives no quantity ('salt and pepper to taste'). Do not invent one.",
+    )
+    note: Optional[str] = Field(
+        default=None,
+        description="Preparation stripped from the name, e.g. 'finely chopped' for '2 onions, finely chopped'.",
+    )
+    group: Optional[str] = Field(
+        default=None,
+        description="The heading this ingredient sat under in the source, e.g. 'For the sauce'.",
+    )
     category: str = Field(default="Other")
     excluded_from_list: bool = Field(default=False)
 
@@ -35,8 +46,35 @@ class Recipe(BaseModel):
     instructions: list[str]
 
 
+class RecipeMetadata(BaseModel):
+    """Provenance and timings that come from an imported page, not from a model.
+
+    Deliberately kept off `Recipe` so none of it reaches the JSON schema we hand
+    Claude. `image_url` and `source_url` in particular have exactly one honest
+    value — whatever the source page published — and a model asked to fill them
+    in will produce a plausible URL that points at nothing.
+
+    Every field is optional, so recipes saved before this existed deserialise
+    unchanged and no migration is needed.
+    """
+
+    servings: Optional[int] = None
+    prep_minutes: Optional[int] = None
+    cook_minutes: Optional[int] = None
+    total_minutes: Optional[int] = None
+    image_url: Optional[str] = None
+    source_url: Optional[str] = None
+    source_name: Optional[str] = None
+    description: Optional[str] = None
+    cuisine: Optional[str] = None
+
+
 class RecipeModelResponse(Recipe):
     ingredients: list[IngredientModelResponse]
+
+
+class ImportFromUrlRequest(BaseModel):
+    url: str
 
 
 class MealIdea(BaseModel):

--- a/server/main.py
+++ b/server/main.py
@@ -2,9 +2,11 @@ import asyncio
 import base64
 import re
 from contextlib import asynccontextmanager
+from urllib.parse import urlparse, urlunparse
 
 from anthropic import AsyncAnthropic, transform_schema
 from beanie import PydanticObjectId, init_beanie
+from bs4 import BeautifulSoup
 from dotenv import load_dotenv
 from fastapi import APIRouter, FastAPI, HTTPException, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
@@ -19,6 +21,7 @@ from lib.types import (
     CategorizeRequest,
     CategorizeResponse,
     ExcludeUpdateRequest,
+    ImportFromUrlRequest,
     IngredientRecipe,
     ItemCreateRequest,
     ItemReorderRequest,
@@ -26,11 +29,14 @@ from lib.types import (
     ListUpdateRequest,
     MealSuggestions,
     RatingUpdate,
+    RecipeMetadata,
     RecipeModelResponse,
     RecipePrompt,
     RecipeUpdateRequest,
     SuggestMealsRequest,
 )
+from ingredient_structurer import structure_ingredients
+from recipe_import import BlockedURL, FetchFailed, ScrapedRecipe, fetch_page, scrape
 from tools import find_similar_ingredients
 
 load_dotenv()
@@ -71,7 +77,9 @@ async def _get_category_names() -> list[str]:
     return [c.name for c in sorted(settings.categories, key=lambda c: c.order)]
 
 
-async def _save_recipe(recipe: RecipeModelResponse) -> RecipeDocument:
+async def _save_recipe(
+    recipe: RecipeModelResponse, metadata: RecipeMetadata | None = None
+) -> RecipeDocument:
     new_ingredients = [i for i in recipe.ingredients if i.is_new]
     existing_ingredients = [i for i in recipe.ingredients if not i.is_new]
 
@@ -101,12 +109,16 @@ async def _save_recipe(recipe: RecipeModelResponse) -> RecipeDocument:
         category = i.category
         if not i.is_new and category == "Other":
             category = category_map.get(i.name.lower(), "Other")
-        ingredients.append(IngredientRecipe(name=i.name, unit=i.unit, amount=i.amount, category=category))
+        ingredients.append(IngredientRecipe(
+            name=i.name, unit=i.unit, amount=i.amount,
+            note=i.note, group=i.group, category=category,
+        ))
 
     db_recipe = RecipeDocument(
         title=recipe.title,
         instructions=recipe.instructions,
         ingredients=ingredients,
+        **(metadata.model_dump() if metadata else {}),
     )
     await db_recipe.insert()
     return db_recipe
@@ -237,6 +249,134 @@ async def extract_recipes_from_images(files: list[UploadFile], group_sizes: list
         return results
 
 
+# --- Import from URL ---
+
+# Enough of a page to hold a recipe, short enough that a content farm's worth of
+# comments doesn't turn the fallback into an expensive call.
+_FALLBACK_TEXT_CHARS = 20000
+
+
+def _canonical_url(raw: str) -> str:
+    """Normalise a submitted URL so dedup doesn't miss obvious repeats.
+
+    Only the fragment is dropped — it never changes what the server returns.
+    Query strings are left alone because plenty of sites put the recipe id
+    there, and stripping them would collapse distinct recipes into one.
+    """
+    parsed = urlparse(raw.strip())
+    return urlunparse(parsed._replace(fragment=""))
+
+
+def _page_text(html: str) -> str:
+    """Reduce a page to readable text for the model fallback."""
+    soup = BeautifulSoup(html, "html.parser")
+    for tag in soup(["script", "style", "noscript"]):
+        tag.decompose()
+    lines = (line.strip() for line in soup.get_text("\n").splitlines())
+    return "\n".join(line for line in lines if line)[:_FALLBACK_TEXT_CHARS]
+
+
+async def _recipe_from_page_text(
+    text: str, categories_str: str
+) -> RecipeModelResponse | None:
+    """Last resort for pages that publish no structured data.
+
+    Returns None when the page has no recipe on it — the model is told to
+    answer with an empty recipe rather than oblige us with an invented one.
+    """
+    runner = async_claude.beta.messages.tool_runner(
+        model="claude-opus-4-5",
+        max_tokens=2048,
+        messages=[{
+            "role": "user",
+            "content": f"Below is the text of a web page. Extract the recipe from it verbatim — the instructions are the author's and must not be rewritten or embellished. Include ingredient amounts directly in the instruction steps (e.g. 'add the 500g pasta' not just 'add the pasta'). Use find_similar_ingredients to match ingredients against the database. For each NEW ingredient (is_new=true), assign a category from this list: [{categories_str}]. For existing ingredients matched via the tool, leave the category as 'Other'.\n\nIf this page does not contain a recipe, return empty values for title, instructions and ingredients rather than composing one.\n\n---\n{text}",
+        }],
+        tools=[find_similar_ingredients],
+        stream=True,
+        output_config={"format": {"type": "json_schema", "schema": recipeSchema}},
+    )
+    final_message = await runner.until_done()
+    recipe = RecipeModelResponse.model_validate_json(final_message.content[0].text)
+
+    if not recipe.title or not recipe.instructions or not recipe.ingredients:
+        return None
+    return recipe
+
+
+def _metadata_from(scraped: ScrapedRecipe) -> RecipeMetadata:
+    return RecipeMetadata(
+        servings=scraped.servings,
+        prep_minutes=scraped.prep_minutes,
+        cook_minutes=scraped.cook_minutes,
+        total_minutes=scraped.total_minutes,
+        image_url=scraped.image_url,
+        source_url=scraped.source_url,
+        source_name=scraped.source_name,
+        description=scraped.description,
+        cuisine=scraped.cuisine,
+    )
+
+
+@router.post("/recipes/import-from-url/")
+async def import_recipe_from_url(body: ImportFromUrlRequest):
+    """Import a recipe from a public web page.
+
+    Two stages: scrape the page for structured data (free), then structure the
+    free-text ingredient lines with Haiku. Pages that publish nothing readable
+    fall back to Opus over the page text.
+    """
+    url = _canonical_url(body.url)
+
+    # Cheapest check first — a re-import shouldn't cost a fetch or a token.
+    # Two simultaneous imports of the same URL can both get past this; the
+    # index is deliberately non-unique, so that races to a duplicate rather
+    # than an error. Re-importing is rare and a duplicate is deletable.
+    existing = await RecipeDocument.find_one(RecipeDocument.source_url == url)
+    if existing:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "message": "That page has already been imported.",
+                "recipe_id": str(existing.id),
+            },
+        )
+
+    try:
+        html = await fetch_page(url)
+    except BlockedURL as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except FetchFailed as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    categories_str = ", ".join(await _get_category_names())
+
+    scraped = scrape(html, url)
+    if scraped:
+        ingredients = await structure_ingredients(
+            scraped.ingredients,
+            categories_str,
+            async_claude,
+            groups=scraped.ingredient_groups,
+        )
+        recipe = RecipeModelResponse(
+            title=scraped.title,
+            instructions=scraped.instructions,
+            ingredients=ingredients,
+        )
+        metadata = _metadata_from(scraped)
+    else:
+        recipe = await _recipe_from_page_text(_page_text(html), categories_str)
+        if not recipe:
+            raise HTTPException(
+                status_code=404, detail="No recipe found on that page."
+            )
+        # Nothing was published to read, so provenance is all we can honestly
+        # record — no image, no times, no servings.
+        metadata = RecipeMetadata(source_url=url, source_name=urlparse(url).hostname)
+
+    return await _save_recipe(recipe, metadata)
+
+
 @router.get("/recipes/")
 async def list_recipes():
     recipes = await RecipeDocument.find_all().sort("-created_at").to_list()
@@ -246,6 +386,11 @@ async def list_recipes():
             "title": r.title,
             "ingredient_count": len(r.ingredients),
             "rating": r.rating,
+            # Enough for a card without shipping the whole document.
+            "image_url": r.image_url,
+            "total_minutes": r.total_minutes,
+            "servings": r.servings,
+            "source_name": r.source_name,
             "created_at": r.created_at.isoformat() if r.created_at else None,
         }
         for r in recipes
@@ -516,6 +661,19 @@ class AddRecipeRequest(BaseModel):
     recipe_id: str
 
 
+def _total_amount(sources: list[ItemSource]) -> float | None:
+    """Sum the quantified sources, ignoring the ones with no amount.
+
+    An item can be contributed by one recipe that says "200g" and another that
+    just says "olive oil". The honest total is 200g — not 200 plus an invented
+    zero — and an item nothing quantifies stays unquantified.
+    """
+    amounts = [s.amount for s in sources if s.amount is not None]
+    if not amounts:
+        return None
+    return round(sum(amounts), 2)
+
+
 @router.post("/lists/{list_id}/recipes")
 async def add_recipe_to_list(list_id: PydanticObjectId, body: AddRecipeRequest):
     lst = await ListDocument.get(list_id)
@@ -546,7 +704,7 @@ async def add_recipe_to_list(list_id: PydanticObjectId, body: AddRecipeRequest):
 
         if matched:
             matched.sources.append(source)
-            matched.amount = round(sum(s.amount for s in matched.sources), 2)
+            matched.amount = _total_amount(matched.sources)
         else:
             lst.items.append(ListItem(
                 name=ing.name,
@@ -581,7 +739,7 @@ async def remove_recipe_from_list(list_id: PydanticObjectId, recipe_id: str):
     for item in lst.items:
         item.sources = [s for s in item.sources if s.recipe_id != recipe_id]
         if item.sources:
-            item.amount = round(sum(s.amount for s in item.sources), 2)
+            item.amount = _total_amount(item.sources)
             remaining_items.append(item)
         # Items with no remaining sources are dropped
     lst.items = remaining_items
@@ -608,7 +766,7 @@ async def add_item(list_id: PydanticObjectId, body: ItemCreateRequest):
         amount=body.amount,
         unit=body.unit,
         category=body.category,
-        sources=[ItemSource(recipe_id=None, amount=body.amount or 0)],
+        sources=[ItemSource(recipe_id=None, amount=body.amount)],
     )
     lst.items.append(item)
     await lst.save()

--- a/server/recipe_import.py
+++ b/server/recipe_import.py
@@ -1,0 +1,297 @@
+"""Fetch and parse recipes from public web pages.
+
+This is stage 1 of the URL import pipeline described in docs/PRD_URL_IMPORT.md:
+fetch a page and pull out whatever structured recipe data it publishes. The
+ingredients come back as free text (``"2 onions, finely chopped"``) because
+recipe-scrapers does not decompose them — turning those lines into structured
+IngredientRecipe objects is stage 2 and lives elsewhere.
+
+The fetch is deliberately paranoid. The URL comes from the caller and we make
+the request, so an unguarded fetch would let anyone reach our loopback
+interface, Railway's private network, or a cloud metadata endpoint. See
+Appendix A of the PRD for the full threat model.
+"""
+
+import asyncio
+import ipaddress
+import re
+import socket
+from dataclasses import dataclass, field
+from typing import Callable, Optional, TypeVar
+from urllib.parse import urlparse
+
+import httpx
+from recipe_scrapers import scrape_html
+from recipe_scrapers._exceptions import (
+    NoSchemaFoundInWildMode,
+    WebsiteNotImplementedError,
+)
+
+_MAX_BYTES = 2 * 1024 * 1024
+_MAX_REDIRECTS = 5
+_TIMEOUT = httpx.Timeout(10.0, connect=5.0)
+# Plenty of recipe sites reject the default httpx agent outright.
+_USER_AGENT = "OmleteBot/1.0 (+https://omlete.app; recipe import)"
+
+# Yields above this are almost certainly a misparse (a stray year, a weight),
+# so we drop them rather than store nonsense.
+_MAX_PLAUSIBLE_SERVINGS = 100
+
+
+class BlockedURL(Exception):
+    """The URL is malformed, or resolves somewhere we refuse to fetch."""
+
+
+class FetchFailed(Exception):
+    """The page could not be retrieved from the origin."""
+
+
+@dataclass
+class IngredientGroup:
+    """A run of ingredients under an optional heading ("For the sauce:")."""
+
+    purpose: Optional[str]
+    ingredients: list[str]
+
+
+@dataclass
+class ScrapedRecipe:
+    """Stage 1 output. `ingredients` is free text pending stage 2."""
+
+    title: str
+    instructions: list[str]
+    ingredients: list[str]
+    source_url: str
+    ingredient_groups: list[IngredientGroup] = field(default_factory=list)
+    servings: Optional[int] = None
+    prep_minutes: Optional[int] = None
+    cook_minutes: Optional[int] = None
+    total_minutes: Optional[int] = None
+    image_url: Optional[str] = None
+    source_name: Optional[str] = None
+    description: Optional[str] = None
+    cuisine: Optional[str] = None
+
+
+# --- SSRF guard ---
+
+
+def _is_forbidden(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """True for anything that isn't a routable public address.
+
+    IPv4-mapped IPv6 (``::ffff:127.0.0.1``) is unwrapped first: IPv6Address
+    reports is_loopback only for ``::1``, so the mapped form would otherwise
+    slip straight through.
+    """
+    mapped = getattr(ip, "ipv4_mapped", None)
+    if mapped is not None:
+        ip = mapped
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
+
+
+async def _resolve(host: str) -> list[str]:
+    """Resolve a hostname to every address it answers with."""
+    loop = asyncio.get_running_loop()
+    try:
+        infos = await loop.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as exc:
+        raise BlockedURL(f"could not resolve {host!r}") from exc
+    return [info[4][0] for info in infos]
+
+
+async def _assert_public(host: str) -> None:
+    """Reject the host if *any* address it resolves to is non-public.
+
+    A name with both an A and an AAAA record has to pass on both — otherwise
+    an attacker publishes one public address to satisfy the check and one
+    private address for the connection to actually use.
+    """
+    addresses = await _resolve(host)
+    if not addresses:
+        raise BlockedURL(f"could not resolve {host!r}")
+
+    for raw in addresses:
+        try:
+            ip = ipaddress.ip_address(raw)
+        except ValueError as exc:  # pragma: no cover - getaddrinfo shouldn't
+            raise BlockedURL(f"unparseable address {raw!r} for {host!r}") from exc
+        if _is_forbidden(ip):
+            raise BlockedURL(f"{host!r} resolves to non-public address {ip}")
+
+
+async def _validate(url: str) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise BlockedURL(f"unsupported scheme: {parsed.scheme!r}")
+    if not parsed.hostname:
+        raise BlockedURL("URL has no hostname")
+    await _assert_public(parsed.hostname)
+
+
+def _make_client(
+    transport: Optional[httpx.AsyncBaseTransport] = None,
+) -> httpx.AsyncClient:
+    """Build the fetch client. `transport` is a seam for tests."""
+    return httpx.AsyncClient(
+        follow_redirects=False,
+        timeout=_TIMEOUT,
+        headers={"User-Agent": _USER_AGENT},
+        transport=transport,
+    )
+
+
+async def fetch_page(url: str) -> str:
+    """Fetch a page as text, re-validating the target on every redirect hop.
+
+    Redirects are followed by hand rather than by httpx: a page that passes the
+    guard can still answer 302 to somewhere private, and httpx's own redirect
+    handling would never re-check.
+    """
+    async with _make_client() as client:
+        for _ in range(_MAX_REDIRECTS):
+            await _validate(url)
+            try:
+                async with client.stream("GET", url) as response:
+                    if response.is_redirect:
+                        location = response.headers.get("location")
+                        if not location:
+                            raise BlockedURL("redirect with no Location header")
+                        url = str(response.url.join(location))
+                        continue
+
+                    if response.status_code >= 400:
+                        raise FetchFailed(
+                            f"{url} returned HTTP {response.status_code}"
+                        )
+
+                    # Enforced while streaming — a Content-Length check would
+                    # trust a header the origin controls.
+                    chunks: list[bytes] = []
+                    total = 0
+                    async for chunk in response.aiter_bytes():
+                        total += len(chunk)
+                        if total > _MAX_BYTES:
+                            raise BlockedURL(
+                                f"response exceeded {_MAX_BYTES} bytes"
+                            )
+                        chunks.append(chunk)
+            except httpx.InvalidURL as exc:
+                # Redirect targets are attacker-controlled, so a Location that
+                # httpx refuses to parse is a rejection, not a fetch failure.
+                raise BlockedURL(f"unusable URL {url!r}: {exc}") from exc
+            except httpx.HTTPError as exc:
+                raise FetchFailed(f"could not fetch {url}: {exc}") from exc
+
+            return b"".join(chunks).decode(
+                response.encoding or "utf-8", errors="replace"
+            )
+
+    raise BlockedURL(f"more than {_MAX_REDIRECTS} redirects")
+
+
+# --- Parsing ---
+
+_T = TypeVar("_T")
+
+
+def _maybe(getter: Callable[[], _T]) -> Optional[_T]:
+    """Call an optional scraper field, treating any failure as absent.
+
+    recipe-scrapers raises rather than returning None for fields a given site
+    doesn't publish, and every one of these is optional for us.
+    """
+    try:
+        value = getter()
+    except Exception:
+        return None
+    return value or None
+
+
+def _parse_servings(raw: Optional[str]) -> Optional[int]:
+    """Pull a serving count out of a yields string.
+
+    recipe-scrapers normalises before we see it — ``"serves 4-6"`` arrives as
+    ``"6 servings"`` (it takes the upper bound of a range) — so the first
+    integer in the string is the one we want.
+    """
+    if not raw:
+        return None
+    match = re.search(r"\d+", raw)
+    if not match:
+        return None
+    value = int(match.group())
+    if value < 1 or value > _MAX_PLAUSIBLE_SERVINGS:
+        return None
+    return value
+
+
+def _clean_lines(values: Optional[list[str]]) -> list[str]:
+    if not values:
+        return []
+    return [line.strip() for line in values if line and line.strip()]
+
+
+def scrape(html: str, url: str) -> Optional[ScrapedRecipe]:
+    """Parse a recipe out of already-fetched HTML.
+
+    Returns None when the page publishes no recipe data we can read, which is
+    the caller's signal to fall back to the model.
+
+    supported_only=False is always passed (it replaces the deprecated
+    wild_mode): the site's dedicated scraper is still used when one exists,
+    and generic schema.org parsing handles everything else, so it is a strict
+    superset of the supported-sites-only behaviour.
+    """
+    try:
+        scraper = scrape_html(html, org_url=url, supported_only=False)
+    except (NoSchemaFoundInWildMode, WebsiteNotImplementedError):
+        return None
+
+    title = _maybe(scraper.title)
+    instructions = _clean_lines(_maybe(scraper.instructions_list))
+    ingredients = _clean_lines(_maybe(scraper.ingredients))
+
+    # A recipe with no title, no steps or no ingredients isn't usable, and
+    # partial schema.org markup on non-recipe pages is common enough to matter.
+    if not title or not instructions or not ingredients:
+        return None
+
+    groups: list[IngredientGroup] = []
+    raw_groups = _maybe(scraper.ingredient_groups) or []
+    for raw_group in raw_groups:
+        group_ingredients = _clean_lines(getattr(raw_group, "ingredients", None))
+        if group_ingredients:
+            groups.append(
+                IngredientGroup(
+                    purpose=getattr(raw_group, "purpose", None),
+                    ingredients=group_ingredients,
+                )
+            )
+
+    return ScrapedRecipe(
+        title=title.strip(),
+        instructions=instructions,
+        ingredients=ingredients,
+        source_url=url,
+        ingredient_groups=groups,
+        servings=_parse_servings(_maybe(scraper.yields)),
+        prep_minutes=_maybe(scraper.prep_time),
+        cook_minutes=_maybe(scraper.cook_time),
+        total_minutes=_maybe(scraper.total_time),
+        image_url=_maybe(scraper.image),
+        source_name=_maybe(scraper.host) or urlparse(url).hostname,
+        description=_maybe(scraper.description),
+        cuisine=_maybe(scraper.cuisine),
+    )
+
+
+async def import_from_url(url: str) -> Optional[ScrapedRecipe]:
+    """Fetch and parse in one step. Raises BlockedURL / FetchFailed."""
+    return scrape(await fetch_page(url), url)

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -9,6 +9,9 @@ annotated-types==0.7.0
 anthropic==0.84.0
 anyio==4.12.1
 attrs==25.4.0
+# A transitive dependency of recipe-scrapers, pinned here because main.py
+# imports it directly to strip pages down to text for the model fallback.
+beautifulsoup4==4.15.0
 certifi==2026.1.4
 charset-normalizer==3.4.5
 click==8.3.1

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -57,6 +57,7 @@ beanie>=1.26,<2
 python-dotenv==1.2.1
 python-multipart==0.0.22
 PyYAML==6.0.3
+recipe-scrapers==15.11.0
 requests==2.32.5
 requests-toolbelt==1.0.0
 rich==14.3.3

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -1,0 +1,9 @@
+import os
+
+# Several modules build their API clients at import time (`tools._service`,
+# `lib.db.vo`, `main.async_claude`), so importing them under test needs keys to
+# exist before the import happens. These are placeholders — every test mocks the
+# client itself, and nothing here reaches the network.
+os.environ.setdefault("VOYAGE_API_KEY", "test-voyage-key")
+os.environ.setdefault("ANTHROPIC_API_KEY", "test-anthropic-key")
+os.environ.setdefault("DB_URI", "mongodb://localhost:27017")

--- a/server/tests/fixtures/recipe_jsonld.html
+++ b/server/tests/fixtures/recipe_jsonld.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en-GB">
+<head>
+<meta charset="utf-8">
+<title>Classic lasagne recipe | Good Food</title>
+<meta property="og:title" content="Classic lasagne">
+<meta property="og:image" content="https://images.example.com/og-lasagne.jpg">
+<link rel="canonical" href="https://www.bbcgoodfood.com/recipes/classic-lasagne">
+<script>window.dataLayer=[{"pageType":"recipe"}];</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebSite",
+      "name": "Good Food",
+      "url": "https://www.bbcgoodfood.com/"
+    },
+    {
+      "@type": "Recipe",
+      "name": "Classic Lasagne",
+      "image": ["https://images.example.com/lasagne.jpg"],
+      "author": {"@type": "Person", "name": "Esther Clark"},
+      "datePublished": "2021-03-01",
+      "description": "A proper family favourite, with a rich ragù and a silky white sauce.",
+      "prepTime": "PT30M",
+      "cookTime": "PT1H30M",
+      "totalTime": "PT2H",
+      "recipeYield": "6 servings",
+      "recipeCategory": "Dinner",
+      "recipeCuisine": "Italian",
+      "aggregateRating": {"@type": "AggregateRating", "ratingValue": "4.7", "ratingCount": "212"},
+      "nutrition": {"@type": "NutritionInformation", "calories": "636 calories", "fatContent": "33 grams fat"},
+      "recipeIngredient": [
+        "1 tbsp olive oil",
+        "2 onions, finely chopped",
+        "3 garlic cloves, crushed",
+        "500g beef mince",
+        "400g can chopped tomatoes",
+        "250g lasagne sheets",
+        "500ml whole milk",
+        "50g butter",
+        "50g plain flour",
+        "100g cheddar, grated"
+      ],
+      "recipeInstructions": [
+        {"@type": "HowToStep", "text": "Heat the 1 tbsp olive oil in a large pan and fry the 2 onions until soft, about 10 mins."},
+        {"@type": "HowToStep", "text": "Add the 3 garlic cloves and 500g beef mince and brown all over."},
+        {"@type": "HowToStep", "text": "Stir in the 400g chopped tomatoes and simmer for 45 mins."},
+        {"@type": "HowToStep", "text": "Make the white sauce with the 50g butter, 50g plain flour and 500ml whole milk."},
+        {"@type": "HowToStep", "text": "Layer with the 250g lasagne sheets, top with the 100g cheddar and bake for 45 mins."}
+      ]
+    }
+  ]
+}
+</script>
+</head>
+<body>
+<div id="cookie-banner">We use cookies. <button>Accept</button></div>
+<nav><ul><li><a href="/recipes">Recipes</a></li><li><a href="/health">Health</a></li></ul></nav>
+<div class="ad-slot" data-ad="leaderboard"></div>
+<article>
+  <h1>Classic lasagne</h1>
+  <p class="standfirst">A proper family favourite.</p>
+  <p>Before we get to the recipe, a word about my grandmother's kitchen in 1974,
+     the smell of soffritto, and why every good lasagne begins with patience.</p>
+  <section class="ingredients"><h2>Ingredients</h2><ul><li>1 tbsp olive oil</li></ul></section>
+  <section class="method"><h2>Method</h2><ol><li>Heat the oil.</li></ol></section>
+  <section class="comments"><h2>Comments (212)</h2><p>Made this last night, delicious!</p></section>
+</article>
+<footer><p>&copy; Example Media</p></footer>
+</body>
+</html>

--- a/server/tests/test_import_from_url.py
+++ b/server/tests/test_import_from_url.py
@@ -1,0 +1,277 @@
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+import main
+from data_models import ItemSource
+from lib.types import ImportFromUrlRequest, IngredientModelResponse
+from recipe_import import BlockedURL, FetchFailed, IngredientGroup, ScrapedRecipe
+
+URL = "https://www.bbcgoodfood.com/recipes/classic-lasagne"
+
+
+def make_scraped(**overrides) -> ScrapedRecipe:
+    base = dict(
+        title="Classic Lasagne",
+        instructions=["Fry the onions.", "Bake for 45 mins."],
+        ingredients=["2 onions, finely chopped", "500g beef mince"],
+        source_url=URL,
+        servings=6,
+        prep_minutes=30,
+        cook_minutes=90,
+        total_minutes=120,
+        image_url="https://images.example.com/lasagne.jpg",
+        source_name="bbcgoodfood.com",
+        description="A proper family favourite.",
+        cuisine="Italian",
+    )
+    base.update(overrides)
+    return ScrapedRecipe(**base)
+
+
+def structured(**overrides) -> IngredientModelResponse:
+    base = {"name": "onions", "unit": "", "amount": 2.0, "is_new": True}
+    base.update(overrides)
+    return IngredientModelResponse(**base)
+
+
+def patch_pipeline(
+    *,
+    existing=None,
+    html="<html></html>",
+    scraped=None,
+    ingredients=None,
+    fetch_error=None,
+):
+    """Patch every collaborator of the import endpoint.
+
+    Returns a context manager yielding the mocks the tests assert against.
+    """
+    recipe_doc = MagicMock()
+    recipe_doc.find_one = AsyncMock(return_value=existing)
+
+    fetch = AsyncMock(side_effect=fetch_error) if fetch_error else AsyncMock(return_value=html)
+    structurer = AsyncMock(return_value=ingredients if ingredients is not None else [structured()])
+    save = AsyncMock(return_value={"saved": True})
+
+    return (
+        patch.multiple(
+            main,
+            RecipeDocument=recipe_doc,
+            fetch_page=fetch,
+            scrape=MagicMock(return_value=scraped),
+            structure_ingredients=structurer,
+            _save_recipe=save,
+            _get_category_names=AsyncMock(return_value=["Fresh Produce", "Other"]),
+        ),
+        {"find_one": recipe_doc.find_one, "fetch": fetch, "structurer": structurer, "save": save},
+    )
+
+
+class TestImportFromUrl:
+    async def test_saves_a_scraped_recipe_with_its_metadata(self):
+        ctx, mocks = patch_pipeline(scraped=make_scraped())
+
+        with ctx:
+            await main.import_recipe_from_url(ImportFromUrlRequest(url=URL))
+
+        recipe, metadata = mocks["save"].call_args.args
+        assert recipe.title == "Classic Lasagne"
+        assert recipe.instructions == ["Fry the onions.", "Bake for 45 mins."]
+        assert metadata.source_url == URL
+        assert metadata.image_url == "https://images.example.com/lasagne.jpg"
+        assert metadata.servings == 6
+        assert metadata.total_minutes == 120
+        assert metadata.cuisine == "Italian"
+
+    async def test_passes_the_free_text_lines_to_the_structurer(self):
+        groups = [IngredientGroup(purpose="For the sauce", ingredients=["2 onions"])]
+        ctx, mocks = patch_pipeline(scraped=make_scraped(ingredient_groups=groups))
+
+        with ctx:
+            await main.import_recipe_from_url(ImportFromUrlRequest(url=URL))
+
+        args, kwargs = mocks["structurer"].call_args
+        assert args[0] == ["2 onions, finely chopped", "500g beef mince"]
+        assert kwargs["groups"] == groups
+
+    async def test_instructions_come_through_verbatim(self):
+        """The whole point of scraping first: the steps are the author's."""
+        steps = ["Do the thing exactly like this.", "Then this."]
+        ctx, mocks = patch_pipeline(scraped=make_scraped(instructions=steps))
+
+        with ctx:
+            await main.import_recipe_from_url(ImportFromUrlRequest(url=URL))
+
+        assert mocks["save"].call_args.args[0].instructions == steps
+
+    async def test_returns_409_and_the_existing_id_for_a_repeat_import(self):
+        existing = MagicMock()
+        existing.id = "abc123"
+        ctx, mocks = patch_pipeline(existing=existing)
+
+        with ctx, pytest.raises(HTTPException) as exc:
+            await main.import_recipe_from_url(ImportFromUrlRequest(url=URL))
+
+        assert exc.value.status_code == 409
+        assert exc.value.detail["recipe_id"] == "abc123"
+        mocks["fetch"].assert_not_called()
+
+    async def test_blocked_url_is_a_client_error(self):
+        ctx, _ = patch_pipeline(fetch_error=BlockedURL("resolves to non-public address"))
+
+        with ctx, pytest.raises(HTTPException) as exc:
+            await main.import_recipe_from_url(
+                ImportFromUrlRequest(url="http://169.254.169.254/latest/meta-data/")
+            )
+
+        assert exc.value.status_code == 400
+
+    async def test_unreachable_source_is_a_gateway_error(self):
+        ctx, _ = patch_pipeline(fetch_error=FetchFailed("connection timed out"))
+
+        with ctx, pytest.raises(HTTPException) as exc:
+            await main.import_recipe_from_url(ImportFromUrlRequest(url=URL))
+
+        assert exc.value.status_code == 502
+
+    async def test_falls_back_to_the_model_when_nothing_is_published(self):
+        ctx, mocks = patch_pipeline(scraped=None, html="<html><body>a blog</body></html>")
+        fallback = main.RecipeModelResponse(
+            title="Blog Lasagne", instructions=["Cook it."], ingredients=[structured()]
+        )
+
+        with ctx, patch.object(
+            main, "_recipe_from_page_text", AsyncMock(return_value=fallback)
+        ) as model:
+            await main.import_recipe_from_url(ImportFromUrlRequest(url=URL))
+
+        model.assert_awaited_once()
+        recipe, metadata = mocks["save"].call_args.args
+        assert recipe.title == "Blog Lasagne"
+        # Nothing was published, so only provenance is recorded.
+        assert metadata.source_url == URL
+        assert metadata.source_name == "www.bbcgoodfood.com"
+        assert metadata.image_url is None
+        assert metadata.servings is None
+
+    async def test_returns_404_when_the_page_has_no_recipe(self):
+        ctx, mocks = patch_pipeline(scraped=None)
+
+        with ctx, patch.object(
+            main, "_recipe_from_page_text", AsyncMock(return_value=None)
+        ), pytest.raises(HTTPException) as exc:
+            await main.import_recipe_from_url(ImportFromUrlRequest(url=URL))
+
+        assert exc.value.status_code == 404
+        mocks["save"].assert_not_called()
+
+    async def test_dedup_lookup_uses_the_canonical_url(self):
+        ctx, mocks = patch_pipeline(scraped=make_scraped())
+
+        with ctx:
+            await main.import_recipe_from_url(
+                ImportFromUrlRequest(url=f"  {URL}#method  ")
+            )
+
+        assert mocks["save"].call_args.args[1].source_url == URL
+
+
+class TestEndToEndAgainstAFixture:
+    """The one test that runs the real scraper through the real endpoint.
+
+    Everything above mocks `scrape`, which means none of it would notice the
+    two halves drifting apart. Only the model call and the save are stubbed
+    here — the page is parsed for real.
+    """
+
+    async def test_a_real_page_reaches_the_structurer_and_the_save(self):
+        html = (Path(__file__).parent / "fixtures" / "recipe_jsonld.html").read_text()
+        recipe_doc = MagicMock()
+        recipe_doc.find_one = AsyncMock(return_value=None)
+        structurer = AsyncMock(return_value=[structured()])
+        save = AsyncMock(return_value={"saved": True})
+
+        with patch.multiple(
+            main,
+            RecipeDocument=recipe_doc,
+            fetch_page=AsyncMock(return_value=html),
+            structure_ingredients=structurer,
+            _save_recipe=save,
+            _get_category_names=AsyncMock(return_value=["Fresh Produce", "Other"]),
+        ):
+            await main.import_recipe_from_url(ImportFromUrlRequest(url=URL))
+
+        # Free-text lines went to stage 2, not structured objects.
+        lines = structurer.call_args.args[0]
+        assert lines and all(isinstance(line, str) for line in lines)
+
+        recipe, metadata = save.call_args.args
+        assert recipe.title
+        assert recipe.instructions
+        assert metadata.source_url == URL
+        assert metadata.total_minutes is not None
+
+
+class TestCanonicalUrl:
+    def test_drops_the_fragment(self):
+        assert main._canonical_url(f"{URL}#ingredients") == URL
+
+    def test_trims_whitespace(self):
+        assert main._canonical_url(f"  {URL}  ") == URL
+
+    def test_keeps_the_query_string(self):
+        """Plenty of sites carry the recipe id in the query."""
+        url = "https://example.com/print?recipe=1234"
+
+        assert main._canonical_url(url) == url
+
+
+class TestPageText:
+    def test_strips_scripts_and_styles(self):
+        html = (
+            "<html><head><style>body{color:red}</style>"
+            "<script>var x = 1;</script></head>"
+            "<body><h1>Lasagne</h1><p>Fry the onions.</p></body></html>"
+        )
+
+        text = main._page_text(html)
+
+        assert "Lasagne" in text
+        assert "Fry the onions." in text
+        assert "var x" not in text
+        assert "color:red" not in text
+
+    def test_drops_blank_lines(self):
+        text = main._page_text("<p>one</p>\n\n\n<p>two</p>")
+
+        assert text == "one\ntwo"
+
+    def test_truncates_a_long_page(self):
+        html = "<p>" + ("word " * 20000) + "</p>"
+
+        assert len(main._page_text(html)) == main._FALLBACK_TEXT_CHARS
+
+
+class TestTotalAmount:
+    """The list-merge arithmetic now that `amount` can be unset."""
+
+    def test_sums_quantified_sources(self):
+        sources = [ItemSource(amount=200.0), ItemSource(amount=100.5)]
+
+        assert main._total_amount(sources) == 300.5
+
+    def test_ignores_unquantified_sources(self):
+        sources = [ItemSource(amount=200.0), ItemSource(amount=None)]
+
+        assert main._total_amount(sources) == 200.0
+
+    def test_stays_unquantified_when_no_source_has_an_amount(self):
+        sources = [ItemSource(amount=None), ItemSource(amount=None)]
+
+        assert main._total_amount(sources) is None
+
+    def test_handles_an_empty_source_list(self):
+        assert main._total_amount([]) is None

--- a/server/tests/test_ingredient_structurer.py
+++ b/server/tests/test_ingredient_structurer.py
@@ -1,0 +1,154 @@
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ingredient_structurer import (
+    MODEL,
+    StructuredIngredients,
+    _build_prompt,
+    _format_lines,
+    structure_ingredients,
+)
+from recipe_import import IngredientGroup
+
+
+def make_client(payload: dict) -> MagicMock:
+    """An AsyncAnthropic stand-in whose runner returns `payload` as JSON."""
+    message = MagicMock()
+    message.content = [MagicMock(text=json.dumps(payload))]
+
+    runner = MagicMock()
+    runner.until_done = AsyncMock(return_value=message)
+
+    client = MagicMock()
+    client.beta.messages.tool_runner = MagicMock(return_value=runner)
+    return client
+
+
+def ingredient(**overrides) -> dict:
+    base = {"name": "onions", "unit": "", "amount": 2.0, "is_new": True}
+    base.update(overrides)
+    return base
+
+
+class TestStructureIngredients:
+    async def test_returns_empty_without_calling_the_model(self):
+        client = make_client({"ingredients": []})
+
+        result = await structure_ingredients([], "Fresh Produce", client)
+
+        assert result == []
+        client.beta.messages.tool_runner.assert_not_called()
+
+    async def test_parses_structured_ingredients(self):
+        client = make_client({
+            "ingredients": [
+                ingredient(name="onions", amount=2.0, unit="", note="finely chopped"),
+                ingredient(name="beef mince", amount=500.0, unit="g"),
+            ]
+        })
+
+        result = await structure_ingredients(
+            ["2 onions, finely chopped", "500g beef mince"], "Fresh Produce", client
+        )
+
+        assert [i.name for i in result] == ["onions", "beef mince"]
+        assert result[0].note == "finely chopped"
+        assert result[1].amount == 500.0
+        assert result[1].unit == "g"
+
+    async def test_unquantified_ingredient_keeps_amount_unset(self):
+        client = make_client({
+            "ingredients": [ingredient(name="salt", unit="", amount=None)]
+        })
+
+        result = await structure_ingredients(
+            ["salt and pepper to taste"], "Pantry & Dry Goods", client
+        )
+
+        assert result[0].amount is None
+
+    async def test_runs_on_haiku(self):
+        client = make_client({"ingredients": [ingredient()]})
+
+        await structure_ingredients(["2 onions"], "Fresh Produce", client)
+
+        kwargs = client.beta.messages.tool_runner.call_args.kwargs
+        assert kwargs["model"] == MODEL
+        assert "haiku" in MODEL
+
+    async def test_offers_the_similarity_tool(self):
+        client = make_client({"ingredients": [ingredient()]})
+
+        await structure_ingredients(["2 onions"], "Fresh Produce", client)
+
+        kwargs = client.beta.messages.tool_runner.call_args.kwargs
+        assert len(kwargs["tools"]) == 1
+
+    async def test_rejects_a_malformed_model_response(self):
+        client = make_client({"wrong_key": []})
+
+        with pytest.raises(Exception):
+            await structure_ingredients(["2 onions"], "Fresh Produce", client)
+
+
+class TestFormatLines:
+    def test_flat_list_when_no_groups(self):
+        rendered = _format_lines(["2 onions", "500g beef mince"], None)
+
+        assert rendered == "- 2 onions\n- 500g beef mince"
+
+    def test_keeps_group_headings(self):
+        groups = [
+            IngredientGroup(purpose="For the sauce", ingredients=["2 onions"]),
+            IngredientGroup(purpose="For the topping", ingredients=["50g cheese"]),
+        ]
+
+        rendered = _format_lines(["2 onions", "50g cheese"], groups)
+
+        assert "For the sauce\n- 2 onions" in rendered
+        assert "For the topping\n- 50g cheese" in rendered
+
+    def test_labels_an_unnamed_group(self):
+        groups = [IngredientGroup(purpose=None, ingredients=["2 onions"])]
+
+        rendered = _format_lines(["2 onions"], groups)
+
+        assert "(no heading)" in rendered
+
+    def test_falls_back_to_the_flat_list_when_groups_lose_ingredients(self):
+        """Groups that don't cover every line are not trustworthy.
+
+        Some sites publish partial ingredient_groups. Rendering those would
+        silently drop whatever they left out, so the flat list wins.
+        """
+        groups = [IngredientGroup(purpose="For the sauce", ingredients=["2 onions"])]
+
+        rendered = _format_lines(["2 onions", "500g beef mince"], groups)
+
+        assert "500g beef mince" in rendered
+        assert "For the sauce" not in rendered
+
+
+class TestBuildPrompt:
+    def test_includes_the_categories(self):
+        prompt = _build_prompt(["2 onions"], "Fresh Produce, Bakery", None)
+
+        assert "[Fresh Produce, Bakery]" in prompt
+
+    def test_tells_the_model_not_to_invent_amounts(self):
+        prompt = _build_prompt(["salt to taste"], "Other", None)
+
+        assert "do not invent one" in prompt
+
+
+class TestSchema:
+    def test_ingredients_wrapper_validates(self):
+        parsed = StructuredIngredients.model_validate(
+            {"ingredients": [ingredient()]}
+        )
+
+        assert parsed.ingredients[0].name == "onions"
+        assert parsed.ingredients[0].category == "Other"
+        assert parsed.ingredients[0].excluded_from_list is False

--- a/server/tests/test_recipe_import.py
+++ b/server/tests/test_recipe_import.py
@@ -1,0 +1,381 @@
+import json
+from pathlib import Path
+from unittest.mock import patch
+from urllib.parse import urlparse
+
+import httpx
+import pytest
+
+import recipe_import
+from recipe_import import (
+    BlockedURL,
+    FetchFailed,
+    _is_forbidden,
+    _parse_servings,
+    fetch_page,
+    scrape,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def build_page(**overrides) -> str:
+    """A minimal page carrying a schema.org/Recipe JSON-LD block."""
+    recipe = {
+        "@context": "https://schema.org",
+        "@type": "Recipe",
+        "name": "Classic Lasagne",
+        "image": ["https://images.example.com/lasagne.jpg"],
+        "description": "A proper family favourite.",
+        "prepTime": "PT30M",
+        "cookTime": "PT1H30M",
+        "totalTime": "PT2H",
+        "recipeYield": "6 servings",
+        "recipeCuisine": "Italian",
+        "recipeIngredient": ["1 tbsp olive oil", "500g beef mince"],
+        "recipeInstructions": [
+            {"@type": "HowToStep", "text": "Fry the onions."},
+            {"@type": "HowToStep", "text": "Bake for 45 mins."},
+        ],
+    }
+    recipe.update(overrides)
+    for key in [k for k, v in recipe.items() if v is None]:
+        del recipe[key]
+    return (
+        '<html><head><script type="application/ld+json">'
+        f"{json.dumps(recipe)}"
+        "</script></head><body><p>blog preamble</p></body></html>"
+    )
+
+
+def patch_resolve(mapping: dict[str, list[str]]):
+    """Patch DNS so resolution is deterministic and offline."""
+
+    async def fake_resolve(host: str) -> list[str]:
+        if host not in mapping:
+            raise BlockedURL(f"could not resolve {host!r}")
+        return mapping[host]
+
+    return patch.object(recipe_import, "_resolve", fake_resolve)
+
+
+def patch_transport(handler):
+    """Route fetches through a MockTransport, keeping the real client config."""
+    real_make_client = recipe_import._make_client
+
+    def make_client() -> httpx.AsyncClient:
+        return real_make_client(transport=httpx.MockTransport(handler))
+
+    return patch.object(recipe_import, "_make_client", make_client)
+
+
+# --- SSRF guard: address classification ---
+
+
+class TestIsForbidden:
+    @pytest.mark.parametrize(
+        "address",
+        [
+            "127.0.0.1",  # loopback
+            "10.0.0.5",  # private
+            "172.16.4.1",  # private
+            "192.168.1.1",  # private
+            "169.254.169.254",  # cloud metadata
+            "0.0.0.0",  # unspecified
+            "224.0.0.1",  # multicast
+            "::1",  # v6 loopback
+            "fd00::1",  # v6 unique-local
+            "fe80::1",  # v6 link-local
+            "::ffff:127.0.0.1",  # IPv4-mapped loopback
+            "::ffff:169.254.169.254",  # IPv4-mapped metadata
+        ],
+    )
+    def test_rejects_non_public(self, address):
+        import ipaddress
+
+        assert _is_forbidden(ipaddress.ip_address(address)) is True
+
+    @pytest.mark.parametrize(
+        "address",
+        ["93.184.216.34", "8.8.8.8", "2606:2800:220:1:248:1893:25c8:1946"],
+    )
+    def test_allows_public(self, address):
+        import ipaddress
+
+        assert _is_forbidden(ipaddress.ip_address(address)) is False
+
+    def test_unwraps_ipv4_mapped_before_classifying(self):
+        """Why the unwrap exists.
+
+        CPython's classification of IPv4-mapped IPv6 has changed across patch
+        releases (CVE-2024-4032 altered is_private/is_global), and this runs on
+        3.11 locally but 3.12 in production. Normalising to the embedded IPv4
+        address makes the verdict ours rather than the stdlib's.
+        """
+        import ipaddress
+
+        mapped = ipaddress.ip_address("::ffff:169.254.169.254")
+        assert mapped.ipv4_mapped == ipaddress.ip_address("169.254.169.254")
+        assert _is_forbidden(mapped) is True
+
+
+# --- SSRF guard: end-to-end through fetch_page ---
+
+
+class TestFetchGuard:
+    async def test_rejects_non_http_scheme(self):
+        with pytest.raises(BlockedURL, match="scheme"):
+            await fetch_page("file:///etc/passwd")
+
+    async def test_rejects_url_without_host(self):
+        with pytest.raises(BlockedURL):
+            await fetch_page("http:///nohost")
+
+    @pytest.mark.parametrize(
+        "url,resolved",
+        [
+            ("http://localhost:8000/", "127.0.0.1"),
+            ("http://169.254.169.254/latest/meta-data/", "169.254.169.254"),
+            ("http://omlete-client.railway.internal/", "fd12::1"),
+            ("http://internal.example/", "10.1.2.3"),
+        ],
+    )
+    async def test_rejects_private_targets(self, url, resolved):
+        host = urlparse(url).hostname
+        with patch_resolve({host: [resolved]}):
+            with pytest.raises(BlockedURL, match="non-public"):
+                await fetch_page(url)
+
+    @pytest.mark.parametrize(
+        "url", ["http://0177.0.0.1/", "http://2130706433/", "http://127.1/"]
+    )
+    async def test_rejects_encoded_loopback_forms(self, url):
+        """Encoded forms resolve to loopback; string matching would miss them."""
+        host = urlparse(url).hostname
+        with patch_resolve({host: ["127.0.0.1"]}):
+            with pytest.raises(BlockedURL, match="non-public"):
+                await fetch_page(url)
+
+    async def test_rejects_when_any_resolved_address_is_private(self):
+        """A public A record does not excuse a private AAAA record."""
+        with patch_resolve({"dual.example": ["93.184.216.34", "10.0.0.1"]}):
+            with pytest.raises(BlockedURL, match="non-public"):
+                await fetch_page("http://dual.example/r")
+
+    async def test_rejects_unresolvable_host(self):
+        with patch_resolve({}):
+            with pytest.raises(BlockedURL, match="resolve"):
+                await fetch_page("http://nope.example/r")
+
+    async def test_revalidates_after_redirect(self):
+        """The hop that matters: public host 302s to the metadata endpoint."""
+        calls = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls.append(str(request.url))
+            return httpx.Response(
+                302, headers={"location": "http://169.254.169.254/"}
+            )
+
+        resolve = {
+            "safe.example": ["93.184.216.34"],
+            "169.254.169.254": ["169.254.169.254"],
+        }
+        with patch_resolve(resolve), patch_transport(handler):
+            with pytest.raises(BlockedURL, match="non-public"):
+                await fetch_page("http://safe.example/r")
+
+        # The first hop was fetched; the second was blocked before any request.
+        assert calls == ["http://safe.example/r"]
+
+    async def test_rejects_redirect_without_location(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(302)
+
+        with patch_resolve({"safe.example": ["93.184.216.34"]}), patch_transport(
+            handler
+        ):
+            with pytest.raises(BlockedURL, match="Location"):
+                await fetch_page("http://safe.example/r")
+
+    async def test_caps_redirect_chain(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(302, headers={"location": "/next"})
+
+        with patch_resolve({"safe.example": ["93.184.216.34"]}), patch_transport(
+            handler
+        ):
+            with pytest.raises(BlockedURL, match="redirects"):
+                await fetch_page("http://safe.example/r")
+
+    async def test_caps_response_size(self):
+        oversized = b"x" * (recipe_import._MAX_BYTES + 1)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=oversized)
+
+        with patch_resolve({"safe.example": ["93.184.216.34"]}), patch_transport(
+            handler
+        ):
+            with pytest.raises(BlockedURL, match="exceeded"):
+                await fetch_page("http://safe.example/big")
+
+    async def test_raises_fetch_failed_on_http_error(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404)
+
+        with patch_resolve({"safe.example": ["93.184.216.34"]}), patch_transport(
+            handler
+        ):
+            with pytest.raises(FetchFailed, match="404"):
+                await fetch_page("http://safe.example/missing")
+
+    async def test_raises_fetch_failed_on_transport_error(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("refused")
+
+        with patch_resolve({"safe.example": ["93.184.216.34"]}), patch_transport(
+            handler
+        ):
+            with pytest.raises(FetchFailed):
+                await fetch_page("http://safe.example/r")
+
+    async def test_fetches_a_public_page(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert "OmleteBot" in request.headers["user-agent"]
+            return httpx.Response(200, text="<html>hi</html>")
+
+        with patch_resolve({"safe.example": ["93.184.216.34"]}), patch_transport(
+            handler
+        ):
+            assert await fetch_page("http://safe.example/r") == "<html>hi</html>"
+
+
+# --- Servings parsing ---
+
+
+class TestParseServings:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("6 servings", 6),
+            ("Serves 4", 4),
+            ("Makes 12 cookies", 12),
+            ("1 loaf", 1),
+            (None, None),
+            ("", None),
+            ("a few", None),
+            ("0 servings", None),
+            ("2024 servings", None),  # implausible, likely a misparse
+        ],
+    )
+    def test_parses(self, raw, expected):
+        assert _parse_servings(raw) == expected
+
+
+# --- Scraping ---
+
+
+class TestScrape:
+    def test_extracts_a_full_recipe(self):
+        result = scrape(build_page(), "https://food.example/lasagne")
+
+        assert result is not None
+        assert result.title == "Classic Lasagne"
+        assert result.instructions == ["Fry the onions.", "Bake for 45 mins."]
+        assert result.ingredients == ["1 tbsp olive oil", "500g beef mince"]
+        assert result.servings == 6
+        assert result.prep_minutes == 30
+        assert result.cook_minutes == 90
+        assert result.total_minutes == 120
+        assert result.image_url == "https://images.example.com/lasagne.jpg"
+        assert result.cuisine == "Italian"
+        assert result.source_url == "https://food.example/lasagne"
+
+    def test_ingredients_stay_free_text(self):
+        """Stage 1 does not decompose ingredients — that's stage 2's job."""
+        page = build_page(recipeIngredient=["2 onions, finely chopped"])
+        result = scrape(page, "https://food.example/r")
+
+        assert result is not None
+        assert result.ingredients == ["2 onions, finely chopped"]
+
+    def test_returns_none_without_structured_data(self):
+        html = "<html><body><p>Just a blog post about my holiday.</p></body></html>"
+        assert scrape(html, "https://blog.example/post") is None
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"recipeIngredient": []},
+            {"recipeInstructions": []},
+            {"name": None},
+        ],
+        ids=["no-ingredients", "no-instructions", "no-title"],
+    )
+    def test_returns_none_when_essentials_missing(self, overrides):
+        assert scrape(build_page(**overrides), "https://food.example/r") is None
+
+    def test_optional_fields_absent_is_fine(self):
+        page = build_page(
+            image=None,
+            prepTime=None,
+            cookTime=None,
+            totalTime=None,
+            recipeYield=None,
+            recipeCuisine=None,
+            description=None,
+        )
+        result = scrape(page, "https://food.example/r")
+
+        assert result is not None
+        assert result.title == "Classic Lasagne"
+        assert result.servings is None
+        assert result.prep_minutes is None
+        assert result.image_url is None
+        assert result.cuisine is None
+
+    def test_takes_upper_bound_of_a_yield_range(self):
+        """Documents recipe-scrapers' behaviour rather than endorsing it."""
+        result = scrape(
+            build_page(recipeYield="serves 4-6"), "https://food.example/r"
+        )
+
+        assert result is not None
+        assert result.servings == 6
+
+    def test_strips_whitespace_and_blank_lines(self):
+        page = build_page(
+            recipeIngredient=["  1 tbsp olive oil  ", "", "   "],
+            recipeInstructions=[
+                {"@type": "HowToStep", "text": "  Fry the onions.  "}
+            ],
+        )
+        result = scrape(page, "https://food.example/r")
+
+        assert result is not None
+        assert result.ingredients == ["1 tbsp olive oil"]
+        assert result.instructions == ["Fry the onions."]
+
+    def test_populates_ingredient_groups(self):
+        result = scrape(build_page(), "https://food.example/r")
+
+        assert result is not None
+        assert len(result.ingredient_groups) == 1
+        assert result.ingredient_groups[0].ingredients == [
+            "1 tbsp olive oil",
+            "500g beef mince",
+        ]
+
+    def test_parses_a_realistic_saved_page(self):
+        """Guards against markup noise a hand-built fixture wouldn't have."""
+        html = (FIXTURES / "recipe_jsonld.html").read_text()
+        result = scrape(html, "https://www.bbcgoodfood.com/recipes/classic-lasagne")
+
+        assert result is not None
+        assert result.title == "Classic Lasagne"
+        assert len(result.ingredients) == 10
+        assert len(result.instructions) == 5
+        assert result.servings == 6
+        assert result.total_minutes == 120
+        assert result.source_name == "bbcgoodfood.com"


### PR DESCRIPTION
Supersedes #51, which carried the PRD and stage 1 on their own. This branch is stacked on top of it, so everything is here in one place.

Implements steps 1-6 of `docs/PRD_URL_IMPORT.md`. Paste a recipe URL on `/create` and get a saved, structured recipe.

## How it works

Two stages, and the cheap one does most of the work:

1. **Scrape** — `recipe_import.fetch_page()` fetches the page behind an SSRF guard, `scrape()` reads its schema.org data: title, instructions, image, times, servings. No tokens. Instructions come through verbatim, so they stay the author's.
2. **Structure** — `ingredient_structurer.structure_ingredients()` splits the free-text ingredient lines (`"2 onions, finely chopped"`) into name/amount/unit on Haiku, canonicalising through `find_similar_ingredients`. Parsing, not generation.

Pages that publish nothing readable fall back to Opus over the page text. Everything saves through the existing `_save_recipe()` path.

## Decisions worth a look

**Metadata went on a `RecipeMetadata` mixin, not on `Recipe` as the PRD specified.** `Recipe` is the base of `RecipeModelResponse`, which generates the JSON schema handed to Claude. Extending it would have put `image_url` and `source_url` in front of a model that cannot know them and would fill them in anyway — plausible URLs pointing at nothing. `RecipeDocument` inherits both; the model only ever sees `Recipe`.

**`amount` is now `Optional[float]`**, resolving the PRD's open question 2. "Salt and pepper to taste" had no honest representation before. `ItemSource` followed it, and both list-merge `sum()` sites go through `_total_amount()`, which ignores unquantified sources rather than adding a zero nobody wrote. This also fixed a latent bug in the recipe editor, which was round-tripping a missing amount through `parseFloat("null") || 0` and silently writing 0.

**The two-phase progress copy runs on a timer.** The import is a single round trip, so the client cannot observe the handover between stages. They do happen in that order; the timing is a guess, and the code says so.

**Error handling needed new plumbing.** `apiFetch` hands back the response untouched, and `fetch` only rejects on network failure — so every existing caller renders a 502's body as though it were data. `apiJson()` throws an `ApiError` carrying the status and FastAPI's `detail`. The 409 branch reads `recipe_id` out of it and links to the recipe imported the first time. Other call sites are left on `apiFetch` deliberately; migrating them changes behaviour outside this feature.

## Verification

- 94 backend tests pass. One deliberately runs the real scraper through the real endpoint against an HTML fixture — the rest mock `scrape`, so nothing else would notice the two halves drifting apart.
- The frontend was driven with Playwright against a stubbed API: default tab, client-side URL check, successful import, and all four error branches. That caught `RecipeHeroImage` hardcoding `w-full` over the caller's `size-16`, which was blowing out the list-row thumbnail.
- `tsc` clean, production build passes, lint back to its two pre-existing errors.
- `recipe-scrapers==15.11.0` installs against the full requirements set with `pip check` clean.

## Not done

- **Rate limiting.** This endpoint makes the server fetch arbitrary URLs and then spends tokens on the result, unauthenticated. It is a cross-cutting #50 P0 item and this should not be publicly reachable without it.
- **No live Haiku call has ever run.** Every structurer test mocks the client, so the PRD's own stated risk — that Haiku 4.5 handles structured output plus tool use reliably — is unverified. Worth one real import before trusting it; `MODEL` is a single constant to change.
- **Step 7, the share target.** The link tab it depends on now exists.
- **Nixpacks build unconfirmed** for the new dependency tree.
- Video links (Instagram, TikTok) fall through to the generic 404 copy. Still an open question in the PRD, so I did not invent an answer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FsPfaeQi33zUw2ekWQr8f3)_